### PR TITLE
Speak the Vial protocol beside rynk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,10 @@ jobs:
 
       - name: Install Linux deps
         if: startsWith(matrix.os, 'ubuntu')
+        # libudev-dev: hidapi's hidraw backend (the Vial transport) links libudev.
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev patchelf libudev-dev
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm build:wasm

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ and macOS 10.15+ (intel/apple).
   feature — and vial-qmk boards — configure over raw HID (USB, or a Bluetooth
   link the OS has already bonded). Vial cannot express everything rynk can:
   key overrides, default layer, reboot, BLE profiles, and live status stay
-  rynk-only, and the UI hides them on a Vial session.
+  rynk-only, and the UI hides them on a Vial session. On Linux, raw-HID access
+  needs the same [udev rule Vial documents](https://get.vial.today/manual/linux-udev.html);
+  building from source additionally needs `libudev-dev`.
 - Reaches a keyboard through an RMK BLE dongle, and binds the keys that pair the two.
 - Support for Windows, macOS, and Linux.
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ and macOS 10.15+ (intel/apple).
 - Based on Rust and Tauri2 frameworks.
 - Concise and modern user interface, built with Svelte 5 and Tailwind CSS 4.
 - Talks the rynk protocol over raw USB (WebUSB in the browser), BLE, and WebHID.
+- Also speaks the classic Vial protocol, so keyboards on RMK's default `vial`
+  feature — and vial-qmk boards — configure over raw HID (USB, or a Bluetooth
+  link the OS has already bonded). Vial cannot express everything rynk can:
+  key overrides, default layer, reboot, BLE profiles, and live status stay
+  rynk-only, and the UI hides them on a Vial session.
 - Reaches a keyboard through an RMK BLE dongle, and binds the keys that pair the two.
 - Support for Windows, macOS, and Linux.
 

--- a/qemu/Cargo.lock
+++ b/qemu/Cargo.lock
@@ -1103,7 +1103,7 @@ checksum = "d3f2ad9f15a07f4a0e1677124f9120ce7e83ab7e1ca7186af0ca9da529b62e80"
 [[package]]
 name = "rmk"
 version = "0.8.2"
-source = "git+https://github.com/rmk-rs/rmk.git?rev=2ca24ad65bd15ee73073df84d47f4a3a17f91fbb#2ca24ad65bd15ee73073df84d47f4a3a17f91fbb"
+source = "git+https://github.com/rmk-rs/rmk.git?rev=0fd8785d669d2139d0a0b75f2441a4d4b463b01a#0fd8785d669d2139d0a0b75f2441a4d4b463b01a"
 dependencies = [
  "byteorder",
  "cortex-m",
@@ -1131,7 +1131,7 @@ dependencies = [
 [[package]]
 name = "rmk-config"
 version = "0.6.1"
-source = "git+https://github.com/rmk-rs/rmk.git?rev=2ca24ad65bd15ee73073df84d47f4a3a17f91fbb#2ca24ad65bd15ee73073df84d47f4a3a17f91fbb"
+source = "git+https://github.com/rmk-rs/rmk.git?rev=0fd8785d669d2139d0a0b75f2441a4d4b463b01a#0fd8785d669d2139d0a0b75f2441a4d4b463b01a"
 dependencies = [
  "config",
  "miniz_oxide",
@@ -1148,7 +1148,7 @@ dependencies = [
 [[package]]
 name = "rmk-macro"
 version = "0.7.1"
-source = "git+https://github.com/rmk-rs/rmk.git?rev=2ca24ad65bd15ee73073df84d47f4a3a17f91fbb#2ca24ad65bd15ee73073df84d47f4a3a17f91fbb"
+source = "git+https://github.com/rmk-rs/rmk.git?rev=0fd8785d669d2139d0a0b75f2441a4d4b463b01a#0fd8785d669d2139d0a0b75f2441a4d4b463b01a"
 dependencies = [
  "cargo_toml",
  "darling 0.23.0",
@@ -1184,7 +1184,7 @@ dependencies = [
 [[package]]
 name = "rmk-types"
 version = "0.2.2"
-source = "git+https://github.com/rmk-rs/rmk.git?rev=2ca24ad65bd15ee73073df84d47f4a3a17f91fbb#2ca24ad65bd15ee73073df84d47f4a3a17f91fbb"
+source = "git+https://github.com/rmk-rs/rmk.git?rev=0fd8785d669d2139d0a0b75f2441a4d4b463b01a#0fd8785d669d2139d0a0b75f2441a4d4b463b01a"
 dependencies = [
  "bitfield-struct",
  "cobs",

--- a/qemu/Cargo.lock
+++ b/qemu/Cargo.lock
@@ -1103,7 +1103,7 @@ checksum = "d3f2ad9f15a07f4a0e1677124f9120ce7e83ab7e1ca7186af0ca9da529b62e80"
 [[package]]
 name = "rmk"
 version = "0.8.2"
-source = "git+https://github.com/rmk-rs/rmk.git?branch=main#ae22ccdab35e6a63bc94247b446f8449e7a23e3b"
+source = "git+https://github.com/rmk-rs/rmk.git?rev=2ca24ad65bd15ee73073df84d47f4a3a17f91fbb#2ca24ad65bd15ee73073df84d47f4a3a17f91fbb"
 dependencies = [
  "byteorder",
  "cortex-m",
@@ -1131,7 +1131,7 @@ dependencies = [
 [[package]]
 name = "rmk-config"
 version = "0.6.1"
-source = "git+https://github.com/rmk-rs/rmk.git?branch=main#ae22ccdab35e6a63bc94247b446f8449e7a23e3b"
+source = "git+https://github.com/rmk-rs/rmk.git?rev=2ca24ad65bd15ee73073df84d47f4a3a17f91fbb#2ca24ad65bd15ee73073df84d47f4a3a17f91fbb"
 dependencies = [
  "config",
  "miniz_oxide",
@@ -1148,7 +1148,7 @@ dependencies = [
 [[package]]
 name = "rmk-macro"
 version = "0.7.1"
-source = "git+https://github.com/rmk-rs/rmk.git?branch=main#ae22ccdab35e6a63bc94247b446f8449e7a23e3b"
+source = "git+https://github.com/rmk-rs/rmk.git?rev=2ca24ad65bd15ee73073df84d47f4a3a17f91fbb#2ca24ad65bd15ee73073df84d47f4a3a17f91fbb"
 dependencies = [
  "cargo_toml",
  "darling 0.23.0",
@@ -1184,7 +1184,7 @@ dependencies = [
 [[package]]
 name = "rmk-types"
 version = "0.2.2"
-source = "git+https://github.com/rmk-rs/rmk.git?branch=main#ae22ccdab35e6a63bc94247b446f8449e7a23e3b"
+source = "git+https://github.com/rmk-rs/rmk.git?rev=2ca24ad65bd15ee73073df84d47f4a3a17f91fbb#2ca24ad65bd15ee73073df84d47f4a3a17f91fbb"
 dependencies = [
  "bitfield-struct",
  "cobs",
@@ -1289,9 +1289,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "sequential-storage"
-version = "7.2.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "574e5a379bf43653079b34cb4cf32958404b5f42e0ed5b5adcdff02c2de04d4d"
+checksum = "e750f14f4f6e5a81277c66311713a56106c8df0196df62a634d1fc806556832b"
 dependencies = [
  "embedded-storage-async",
  "postcard",

--- a/qemu/Cargo.toml
+++ b/qemu/Cargo.toml
@@ -20,7 +20,7 @@ bench = false
 locked = []
 
 [dependencies]
-rmk = { git = "https://github.com/rmk-rs/rmk.git", rev = "2ca24ad65bd15ee73073df84d47f4a3a17f91fbb", default-features = false, features = [ "rynk" ] }
+rmk = { git = "https://github.com/rmk-rs/rmk.git", rev = "0fd8785d669d2139d0a0b75f2441a4d4b463b01a", default-features = false, features = [ "rynk" ] }
 embassy-executor = { version = "0.10", features = [
   "platform-riscv32",
   "executor-thread"
@@ -42,4 +42,4 @@ static_cell = "2.0"
 uart_16550 = "0.6"
 
 [build-dependencies]
-rmk-config = { git = "https://github.com/rmk-rs/rmk.git", rev = "2ca24ad65bd15ee73073df84d47f4a3a17f91fbb" }
+rmk-config = { git = "https://github.com/rmk-rs/rmk.git", rev = "0fd8785d669d2139d0a0b75f2441a4d4b463b01a" }

--- a/qemu/Cargo.toml
+++ b/qemu/Cargo.toml
@@ -20,7 +20,7 @@ bench = false
 locked = []
 
 [dependencies]
-rmk = { git = "https://github.com/rmk-rs/rmk.git", rev = "65df15775026bad1189139613ee3d338139bec3d", default-features = false, features = [ "rynk" ] }
+rmk = { git = "https://github.com/rmk-rs/rmk.git", rev = "2ca24ad65bd15ee73073df84d47f4a3a17f91fbb", default-features = false, features = [ "rynk" ] }
 embassy-executor = { version = "0.10", features = [
   "platform-riscv32",
   "executor-thread"
@@ -42,4 +42,4 @@ static_cell = "2.0"
 uart_16550 = "0.6"
 
 [build-dependencies]
-rmk-config = { git = "https://github.com/rmk-rs/rmk.git", rev = "65df15775026bad1189139613ee3d338139bec3d" }
+rmk-config = { git = "https://github.com/rmk-rs/rmk.git", rev = "2ca24ad65bd15ee73073df84d47f4a3a17f91fbb" }

--- a/qemu/harness.ts
+++ b/qemu/harness.ts
@@ -1,0 +1,111 @@
+import type { ChildProcess } from 'node:child_process'
+import type { JsByteLink } from '../src/rynk/core'
+import { spawn } from 'node:child_process'
+import net from 'node:net'
+import process from 'node:process'
+
+export function socketLink(sock: net.Socket): JsByteLink {
+  const chunks: Uint8Array[] = []
+  let wake: (() => void) | null = null
+  let closed = false
+  const signal = () => {
+    const w = wake
+    wake = null
+    w?.()
+  }
+  sock.on('data', (d: Buffer) => { chunks.push(new Uint8Array(d)); signal() })
+  sock.on('close', () => { closed = true; signal() })
+  sock.on('error', () => { closed = true; signal() })
+
+  return {
+    label: 'qemu',
+    async send(frame) {
+      await new Promise<void>((res, rej) => {
+        sock.write(frame, e => (e ? rej(e) : res()))
+      })
+    },
+    async recv() {
+      while (!chunks.length && !closed) await new Promise<void>((res) => { wake = res })
+      return chunks.shift() ?? new Uint8Array(0)
+    },
+    async close() { sock.destroy() },
+  }
+}
+
+/// Let the OS pick the port, then hand it to qemu. A fixed one lets an
+/// unrelated listener answer dial(), or makes the spawn fail outright.
+export async function freePort(): Promise<number> {
+  const srv = net.createServer()
+  await new Promise<void>((res, rej) => {
+    srv.once('error', rej)
+    srv.listen(0, '127.0.0.1', res)
+  })
+  const { port } = srv.address() as net.AddressInfo
+  await new Promise<void>((res) => { srv.close(() => res()) })
+  return port
+}
+
+/// Printed by qemu/src/main.rs once its UART is initialised. Until then the
+/// fixture resets the 16550 FIFO, discarding anything the host already sent —
+/// and qemu accepts the connection during machine init, well before that.
+const UART_READY = '[RMK] uart ready'
+
+async function waitForLine(log: string[], needle: string, child: ChildProcess, deadlineMs: number) {
+  const start = Date.now()
+  while (!log.join('').includes(needle)) {
+    if (child.exitCode !== null) throw new Error(`qemu exited ${child.exitCode} before ${needle}`)
+    if (Date.now() - start > deadlineMs) throw new Error(`timed out waiting for ${needle}`)
+    await new Promise((r) => { setTimeout(r, 100) })
+  }
+}
+
+export async function dial(port: number, deadlineMs: number): Promise<net.Socket> {
+  const start = Date.now()
+  for (;;) {
+    try {
+      return await new Promise<net.Socket>((res, rej) => {
+        const s = net.createConnection({ host: '127.0.0.1', port })
+        s.once('connect', () => res(s))
+        s.once('error', rej)
+      })
+    }
+    catch (e) {
+      if (Date.now() - start > deadlineMs) throw e
+      await new Promise((r) => { setTimeout(r, 200) })
+    }
+  }
+}
+
+export interface QemuFixture {
+  qemu: ChildProcess
+  port: number
+  /// Everything the build and the guest printed, for post-mortems.
+  log: string[]
+}
+
+/// Builds (when stale) and boots the fixture firmware, resolving once its
+/// serial port is safe to talk to.
+export async function spawnQemu(): Promise<QemuFixture> {
+  const port = await freePort()
+  const qemu = spawn('node', ['run.mjs'], {
+    cwd: new URL('.', import.meta.url).pathname,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env, RMK_QEMU_PORT: String(port) },
+  })
+  // Held rather than inherited: cargo's progress would drown the reporter, but
+  // a failed handshake is undebuggable without the build and semihosting output.
+  const log: string[] = []
+  qemu.stdout?.on('data', (d: Buffer) => log.push(d.toString()))
+  qemu.stderr?.on('data', (d: Buffer) => log.push(d.toString()))
+  process.on('exit', () => qemu.kill('SIGKILL'))
+  try {
+    // Generous: this also covers a cold cargo build of the riscv firmware.
+    await waitForLine(log, UART_READY, qemu, 600_000)
+  }
+  catch (e) {
+    console.error(`--- qemu on port ${port} ---\n${log.join('')}`)
+    qemu.kill('SIGTERM')
+    throw e
+  }
+  return { qemu, port, log }
+}

--- a/qemu/smoke.test.ts
+++ b/qemu/smoke.test.ts
@@ -1,5 +1,6 @@
 import type { ChildProcess } from 'node:child_process'
 import type { JsByteLink, RynkClient } from '../src/rynk/core'
+import type { KeyAction, Morse } from '../src/rynk/wasm/rynk_wasm.js'
 import { spawn } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import net from 'node:net'
@@ -14,6 +15,11 @@ const ROWS = 4
 const COLS = 12
 const LAYERS = 2
 const ENCODERS = 2
+
+/// A plain key as the wire spells it.
+function KEY(code: string): KeyAction {
+  return { Single: { Key: { Hid: code as never } } }
+}
 
 function socketLink(sock: net.Socket): JsByteLink {
   const chunks: Uint8Array[] = []
@@ -134,6 +140,26 @@ it('reads the whole keymap in one paged transfer', async () => {
   expect(flat).toHaveLength(LAYERS * ROWS * COLS)
 })
 
+it('serves the fixture keymap values', async () => {
+  // get_default_keymap() in qemu/src/main.rs.
+  expect(await client.get_key(0, 0, 0)).toEqual(KEY('Q'))
+  expect(await client.get_key(0, 2, 5)).toEqual(KEY('LCtrl'))
+  expect(await client.get_key(0, 3, 8)).toEqual({ Single: { LayerOn: 1 } })
+  expect(await client.get_key(1, 0, 0)).toBe('Transparent')
+})
+
+it('serves the fixture encoder map', async () => {
+  // DEFAULT_ENCODER_MAP in qemu/src/main.rs.
+  expect(await client.get_encoder(0, 0)).toEqual({
+    clockwise: KEY('AudioVolUp'),
+    counter_clockwise: KEY('AudioVolDown'),
+  })
+  expect(await client.get_encoder(1, 1)).toEqual({
+    clockwise: KEY('Home'),
+    counter_clockwise: KEY('End'),
+  })
+})
+
 it('round-trips a key write', async () => {
   const original = await client.get_key(0, 0, 0)
   expect(original).not.toBe('Transparent')
@@ -157,6 +183,97 @@ it('round-trips an encoder write', async () => {
   finally {
     await client.set_encoder(0, 0, original)
   }
+})
+
+it('serves every table filled to its capacity, ending with Invalid', async () => {
+  // initialize_keymap pads combos, forks and morses to their build-time
+  // capacity, so the caps maxima double as the live table lengths. The pad
+  // slots read back empty, and the first index past the table is Invalid —
+  // which is how a host must find the end on a firmware that doesn't pad.
+  const caps = await client.get_capabilities()
+  const combos = await client.read_all_combos()
+  expect(combos).toHaveLength(caps.max_combos)
+  expect(combos.every(c => c.actions.length === 0)).toBe(true)
+  expect(await client.read_all_morses()).toHaveLength(caps.max_morse)
+  expect((await client.get_fork(caps.max_forks - 1)).trigger).toBe('No')
+  await expect(client.get_fork(caps.max_forks)).rejects.toThrow('device rejected Invalid')
+})
+
+it('serves the fixture fork', async () => {
+  const fork = await client.get_fork(0)
+  expect(fork.trigger).toEqual(KEY('A'))
+  expect(fork.negative_output).toEqual(KEY('B'))
+  expect(fork.positive_output).toEqual(KEY('C'))
+  expect(fork.bindable).toBe(true)
+})
+
+it('round-trips a fork write', async () => {
+  const original = await client.get_fork(0)
+  const swapped = {
+    ...original,
+    negative_output: original.positive_output,
+    positive_output: original.negative_output,
+  }
+  try {
+    await client.set_fork(0, swapped)
+    expect(await client.get_fork(0)).toEqual(swapped)
+  }
+  finally {
+    await client.set_fork(0, original)
+  }
+})
+
+it('round-trips a morse write', async () => {
+  const original = await client.get_morse(0)
+  expect(original.actions).toEqual([])
+  const morse: Morse = {
+    profile: { ...original.profile, hold_timeout_ms: 240 },
+    // 0b10 = tap, 0b101 = tap-then-hold.
+    actions: [[0b10, { Key: { Hid: 'A' as never } }], [0b101, { Key: { Hid: 'B' as never } }]],
+  }
+  try {
+    await client.set_morse(0, morse)
+    expect(await client.get_morse(0)).toEqual(morse)
+  }
+  finally {
+    await client.set_morse(0, original)
+  }
+})
+
+it('round-trips the default layer', async () => {
+  expect(await client.get_default_layer()).toBe(0)
+  try {
+    await client.set_default_layer(1)
+    expect(await client.get_default_layer()).toBe(1)
+  }
+  finally {
+    await client.set_default_layer(0)
+  }
+})
+
+it('round-trips the behavior config', async () => {
+  const original = await client.get_behavior()
+  const next = {
+    combo_timeout_ms: 77,
+    oneshot_timeout_ms: 850,
+    tap_interval_ms: 25,
+    tap_capslock_interval_ms: 350,
+  }
+  try {
+    await client.set_behavior(next)
+    expect(await client.get_behavior()).toEqual(next)
+  }
+  finally {
+    await client.set_behavior(original)
+  }
+})
+
+it('reads an idle matrix as all zeros', async () => {
+  // The firmware serves its full MATRIX_BITMAP_SIZE buffer; the host slices
+  // by geometry. Nothing presses keys under qemu, so every byte is clear.
+  const state = await client.get_matrix_state()
+  expect(state.pressed_bitmap).toHaveLength(32)
+  expect(state.pressed_bitmap.every(b => b === 0)).toBe(true)
 })
 
 it('pushes topic events', async () => {

--- a/qemu/smoke.test.ts
+++ b/qemu/smoke.test.ts
@@ -1,12 +1,11 @@
 import type { ChildProcess } from 'node:child_process'
-import type { JsByteLink, RynkClient } from '../src/rynk/core'
+import type net from 'node:net'
+import type { RynkClient } from '../src/rynk/core'
 import type { KeyAction, Morse } from '../src/rynk/wasm/rynk_wasm.js'
-import { spawn } from 'node:child_process'
 import { readFileSync } from 'node:fs'
-import net from 'node:net'
-import process from 'node:process'
 import { afterAll, beforeAll, expect, it } from 'vitest'
 import { connectClient } from '../src/rynk/core'
+import { dial, socketLink, spawnQemu } from './harness'
 
 const WASM = readFileSync(new URL('../src/rynk/wasm/rynk_wasm_bg.wasm', import.meta.url))
 
@@ -21,104 +20,15 @@ function KEY(code: string): KeyAction {
   return { Single: { Key: { Hid: code as never } } }
 }
 
-function socketLink(sock: net.Socket): JsByteLink {
-  const chunks: Uint8Array[] = []
-  let wake: (() => void) | null = null
-  let closed = false
-  const signal = () => {
-    const w = wake
-    wake = null
-    w?.()
-  }
-  sock.on('data', (d: Buffer) => { chunks.push(new Uint8Array(d)); signal() })
-  sock.on('close', () => { closed = true; signal() })
-  sock.on('error', () => { closed = true; signal() })
-
-  return {
-    label: 'qemu',
-    async send(frame) {
-      await new Promise<void>((res, rej) => {
-        sock.write(frame, e => (e ? rej(e) : res()))
-      })
-    },
-    async recv() {
-      while (!chunks.length && !closed) await new Promise<void>((res) => { wake = res })
-      return chunks.shift() ?? new Uint8Array(0)
-    },
-    async close() { sock.destroy() },
-  }
-}
-
-/// Let the OS pick the port, then hand it to qemu. A fixed one lets an
-/// unrelated listener answer dial(), or makes the spawn fail outright.
-async function freePort(): Promise<number> {
-  const srv = net.createServer()
-  await new Promise<void>((res, rej) => {
-    srv.once('error', rej)
-    srv.listen(0, '127.0.0.1', res)
-  })
-  const { port } = srv.address() as net.AddressInfo
-  await new Promise<void>((res) => { srv.close(() => res()) })
-  return port
-}
-
-/// Printed by qemu/src/main.rs once its UART is initialised. Until then the
-/// fixture resets the 16550 FIFO, discarding anything the host already sent —
-/// and qemu accepts the connection during machine init, well before that.
-const UART_READY = '[RMK] uart ready'
-
-async function waitForLine(log: string[], needle: string, child: ChildProcess, deadlineMs: number) {
-  const start = Date.now()
-  while (!log.join('').includes(needle)) {
-    if (child.exitCode !== null) throw new Error(`qemu exited ${child.exitCode} before ${needle}`)
-    if (Date.now() - start > deadlineMs) throw new Error(`timed out waiting for ${needle}`)
-    await new Promise((r) => { setTimeout(r, 100) })
-  }
-}
-
-async function dial(port: number, deadlineMs: number): Promise<net.Socket> {
-  const start = Date.now()
-  for (;;) {
-    try {
-      return await new Promise<net.Socket>((res, rej) => {
-        const s = net.createConnection({ host: '127.0.0.1', port })
-        s.once('connect', () => res(s))
-        s.once('error', rej)
-      })
-    }
-    catch (e) {
-      if (Date.now() - start > deadlineMs) throw e
-      await new Promise((r) => { setTimeout(r, 200) })
-    }
-  }
-}
-
 let qemu: ChildProcess
 let sock: net.Socket
 let client: RynkClient
 
 beforeAll(async () => {
-  const port = await freePort()
-  qemu = spawn('node', ['run.mjs'], {
-    cwd: new URL('.', import.meta.url).pathname,
-    stdio: ['ignore', 'pipe', 'pipe'],
-    env: { ...process.env, RMK_QEMU_PORT: String(port) },
-  })
-  // Held rather than inherited: cargo's progress would drown the reporter, but
-  // a failed handshake is undebuggable without the build and semihosting output.
-  const log: string[] = []
-  qemu.stdout?.on('data', (d: Buffer) => log.push(d.toString()))
-  qemu.stderr?.on('data', (d: Buffer) => log.push(d.toString()))
-  try {
-    // Generous: this also covers a cold cargo build of the riscv firmware.
-    await waitForLine(log, UART_READY, qemu, 600_000)
-    sock = await dial(port, 30_000)
-    client = (await connectClient(socketLink(sock), WASM)).client
-  }
-  catch (e) {
-    console.error(`--- qemu on port ${port} ---\n${log.join('')}`)
-    throw e
-  }
+  const fixture = await spawnQemu()
+  qemu = fixture.qemu
+  sock = await dial(fixture.port, 30_000)
+  client = (await connectClient(socketLink(sock), WASM)).client
 })
 
 afterAll(() => {
@@ -287,4 +197,3 @@ it('exposes the lock gate as unlocked', async () => {
   expect((await client.get_lock_status()).locked).toBe(false)
 })
 
-process.on('exit', () => qemu?.kill('SIGKILL'))

--- a/qemu/store.test.ts
+++ b/qemu/store.test.ts
@@ -1,0 +1,207 @@
+import type { ChildProcess } from 'node:child_process'
+import type net from 'node:net'
+import type { KeyboardConfig } from '../src/stores'
+import { readFileSync } from 'node:fs'
+import { afterAll, beforeAll, expect, it, vi } from 'vitest'
+import { encodeMacros } from '../src/lib/macro-codec'
+import { keycodeTables } from '../src/rynk/core'
+import { keyboardStore } from '../src/stores'
+import { dial, socketLink, spawnQemu } from './harness'
+
+/// The full store pipeline — validation, serialization, the request chain,
+/// optimistic state and the topic pump — against the real fixture firmware.
+/// The raw protocol surface is smoke.test.ts's job; here every assertion goes
+/// through keyboardStore, the way the UI does it.
+
+const WASM = readFileSync(new URL('../src/rynk/wasm/rynk_wasm_bg.wasm', import.meta.url))
+
+let qemu: ChildProcess
+let sock: net.Socket
+
+/// Deep copy that reads through the store's $state proxies.
+function snapshot<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
+}
+
+beforeAll(async () => {
+  // The store loads the wasm with no explicit bytes, which Node's fetch cannot
+  // serve from a file: URL — initialising the module here first makes the
+  // store's own init a no-op reuse of the same instance.
+  await keycodeTables(WASM)
+  const fixture = await spawnQemu()
+  qemu = fixture.qemu
+  sock = await dial(fixture.port, 30_000)
+  const result = await keyboardStore.initStore({ link: socketLink(sock), label: 'qemu' })
+  expect(result.isOk()).toBe(true)
+})
+
+afterAll(async () => {
+  await keyboardStore.resetStore()
+  sock?.destroy()
+  qemu?.kill('SIGTERM')
+})
+
+it('connects and lands the whole fixture config in the store', () => {
+  expect(keyboardStore.connection?.phase).toBe('connected')
+
+  const caps = keyboardStore.device!.capabilities
+  expect(caps.num_rows).toBe(4)
+  expect(caps.num_cols).toBe(12)
+  expect(caps.num_layers).toBe(2)
+  expect(caps.num_encoders).toBe(2)
+
+  const config = keyboardStore.config!
+  // Known fixture values from qemu/src/main.rs.
+  expect(config.keymap[0]![0]![0]).toEqual({ Single: { Key: { Hid: 'Q' } } })
+  expect(config.keymap[0]![3]![8]).toEqual({ Single: { LayerOn: 1 } })
+  expect(config.keymap[1]![0]![0]).toBe('Transparent')
+  expect(config.encoders[0]![0]).toEqual({
+    clockwise: { Single: { Key: { Hid: 'AudioVolUp' } } },
+    counter_clockwise: { Single: { Key: { Hid: 'AudioVolDown' } } },
+  })
+  expect(config.forks[0]!.trigger).toEqual({ Single: { Key: { Hid: 'A' } } })
+  // Tables come padded to capacity on this firmware.
+  expect(config.combos).toHaveLength(caps.max_combos)
+  expect(config.morses).toHaveLength(caps.max_morse)
+  expect(config.forks).toHaveLength(caps.max_forks)
+  expect(config.macros).toHaveLength(caps.macro_space_size)
+  expect(config.defaultLayer).toBe(0)
+
+  const status = keyboardStore.status!
+  expect(status.lockStatus.locked).toBe(false)
+  expect(status.matrixState?.pressed_bitmap.every(b => b === 0)).toBe(true)
+})
+
+it('streams the fixture topics into the status', async () => {
+  // test_topics publishes wpm/layer/led/sleep on a 200ms cadence.
+  await vi.waitFor(() => expect(keyboardStore.status!.wpm).toBeGreaterThan(0), { timeout: 5_000 })
+})
+
+it('writes a key and restores it', async () => {
+  expect((await keyboardStore.setKey(0, 0, 0, 'Transparent')).isOk()).toBe(true)
+  expect(keyboardStore.config!.keymap[0]![0]![0]).toBe('Transparent')
+  expect((await keyboardStore.setKey(0, 0, 0, { Single: { Key: { Hid: 'Q' } } })).isOk()).toBe(true)
+})
+
+it('rejects a key outside the matrix without touching the device', async () => {
+  const result = await keyboardStore.setKey(0, 9, 0, 'Transparent')
+  expect(result._unsafeUnwrapErr().type).toBe('invalid')
+})
+
+it('writes a combo and clears it', async () => {
+  const combo = {
+    actions: [
+      { Single: { Key: { Hid: 'J' } } },
+      { Single: { Key: { Hid: 'K' } } },
+    ],
+    output: { Single: { Key: { Hid: 'Escape' } } },
+    layer: undefined,
+  }
+  expect((await keyboardStore.setCombo(0, combo)).isOk()).toBe(true)
+  expect(keyboardStore.config!.combos[0]).toEqual(combo)
+  expect((await keyboardStore.setCombo(0, { actions: [], output: 'No', layer: undefined })).isOk()).toBe(true)
+})
+
+it('writes a morse key and clears it', async () => {
+  const original = snapshot(keyboardStore.config!.morses[0]!)
+  const morse = {
+    profile: { ...original.profile, hold_timeout_ms: 180 },
+    actions: [[0b10, { Key: { Hid: 'A' } }]] as [number, { Key: { Hid: 'A' } }][],
+  }
+  expect((await keyboardStore.setMorse(0, morse)).isOk()).toBe(true)
+  expect(keyboardStore.config!.morses[0]).toEqual(morse)
+  expect((await keyboardStore.setMorse(0, original)).isOk()).toBe(true)
+})
+
+it('rewrites the fixture fork and restores it', async () => {
+  const original = snapshot(keyboardStore.config!.forks[0]!)
+  const swapped = {
+    ...original,
+    negative_output: original.positive_output,
+    positive_output: original.negative_output,
+  }
+  expect((await keyboardStore.setFork(0, swapped)).isOk()).toBe(true)
+  expect(keyboardStore.config!.forks[0]).toEqual(swapped)
+  expect((await keyboardStore.setFork(0, original)).isOk()).toBe(true)
+})
+
+it('writes an encoder direction and restores it', async () => {
+  const original = snapshot(keyboardStore.config!.encoders[0]![0]!)
+  const swapped = { clockwise: original.counter_clockwise, counter_clockwise: original.clockwise }
+  expect((await keyboardStore.setEncoder(0, 0, swapped)).isOk()).toBe(true)
+  expect(keyboardStore.config!.encoders[0]![0]).toEqual(swapped)
+  expect((await keyboardStore.setEncoder(0, 0, original)).isOk()).toBe(true)
+})
+
+it('moves the default layer and back', async () => {
+  expect((await keyboardStore.setDefaultLayer(1)).isOk()).toBe(true)
+  expect(keyboardStore.config!.defaultLayer).toBe(1)
+  expect((await keyboardStore.setDefaultLayer(0)).isOk()).toBe(true)
+})
+
+it('writes the behavior timing and restores it', async () => {
+  const original = snapshot(keyboardStore.config!.behavior)
+  const next = { ...original, combo_timeout_ms: 66 }
+  expect((await keyboardStore.setBehavior(next)).isOk()).toBe(true)
+  expect(keyboardStore.config!.behavior.combo_timeout_ms).toBe(66)
+  expect((await keyboardStore.setBehavior(original)).isOk()).toBe(true)
+})
+
+it('writes the macro region through the app codec', async () => {
+  const caps = keyboardStore.device!.capabilities
+  // The fixture ships macro storage; a build without it would zero this and
+  // the macros screen would not exist to write anything.
+  expect(caps.macro_space_size).toBeGreaterThan(0)
+  const original = snapshot(keyboardStore.config!.macros)
+  const slots = Array.from({ length: 8 }, () => [] as never[])
+  const bytes = encodeMacros([[{ kind: 'text', value: 'hi' }], ...slots.slice(1)], caps.macro_space_size)!
+  expect(bytes).not.toBeNull()
+  expect((await keyboardStore.setMacroRegion(bytes)).isOk()).toBe(true)
+  expect(keyboardStore.config!.macros).toEqual(bytes)
+  expect((await keyboardStore.setMacroRegion(original)).isOk()).toBe(true)
+})
+
+it('polls the matrix state on demand', async () => {
+  const result = await keyboardStore.refreshMatrixState()
+  expect(result._unsafeUnwrap()?.pressed_bitmap.every(b => b === 0)).toBe(true)
+})
+
+it('keeps the lock gate open on the insecure fixture', async () => {
+  // lock() is a no-op on a firmware built without unlock keys; the store
+  // re-reads the status rather than assuming the command latched.
+  expect((await keyboardStore.lock()).isOk()).toBe(true)
+  expect(keyboardStore.status!.lockStatus.locked).toBe(false)
+  const poll = await keyboardStore.unlockPoll()
+  expect(poll._unsafeUnwrap().locked).toBe(false)
+})
+
+it('imports a modified backup and lands the device view', async () => {
+  const original = snapshot(keyboardStore.config!)
+  const edited = snapshot(original)
+  edited.keymap[0]![0]![1] = { Single: { Key: { Hid: 'X' } } }
+  edited.defaultLayer = 1
+
+  expect((await keyboardStore.importConfig(edited)).isOk()).toBe(true)
+  // importConfig re-reads the device after writing, so this is the firmware's
+  // own view of what landed — not the draft we handed in.
+  expect(keyboardStore.config!.keymap[0]![0]![1]).toEqual({ Single: { Key: { Hid: 'X' } } })
+  expect(keyboardStore.config!.defaultLayer).toBe(1)
+
+  expect((await keyboardStore.importConfig(original)).isOk()).toBe(true)
+  expect(keyboardStore.config!.keymap[0]![0]![1]).toEqual({ Single: { Key: { Hid: 'W' } } })
+  expect(keyboardStore.config!.defaultLayer).toBe(0)
+})
+
+it('refuses a backup with foreign geometry before writing', async () => {
+  const alien = snapshot(keyboardStore.config!)
+  alien.keymap = [[['No']]]
+  const result = await keyboardStore.importConfig(alien)
+  expect(result._unsafeUnwrapErr().type).toBe('invalid')
+})
+
+it('disconnects cleanly', async () => {
+  await keyboardStore.disconnect()
+  expect(keyboardStore.connection?.phase).toBe('disconnected')
+  expect(keyboardStore.config).toBeNull()
+  expect(keyboardStore.status).toBeNull()
+})

--- a/scripts/build-rynk-wasm.py
+++ b/scripts/build-rynk-wasm.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 # Keep REV in step with the rmk pins in qemu/Cargo.toml and src-tauri/Cargo.toml —
 # firmware and wasm client must come from one protocol commit.
-URL, REV = "https://github.com/rmk-rs/rmk.git", "2ca24ad65bd15ee73073df84d47f4a3a17f91fbb"
+URL, REV = "https://github.com/rmk-rs/rmk.git", "0fd8785d669d2139d0a0b75f2441a4d4b463b01a"
 ROOT = Path(__file__).resolve().parent.parent
 WASM_OUT = ROOT / "src" / "rynk" / "wasm"
 
@@ -31,7 +31,12 @@ def resolve_repo():
 
 repo, temporary = resolve_repo()
 print(f"building rynk-wasm from {repo}")
-subprocess.run(["wasm-pack", "build", "--target", "web", "--release", str(repo / "rynk" / "rynk-wasm")], check=True)
+# `vial` compiles the Vial host client in next to the rynk one, so the GUI can
+# also drive keyboards on the legacy protocol.
+subprocess.run(
+    ["wasm-pack", "build", "--target", "web", "--release", str(repo / "rynk" / "rynk-wasm"), "--features", "vial"],
+    check=True,
+)
 shutil.rmtree(WASM_OUT, ignore_errors=True)
 shutil.copytree(repo / "rynk" / "rynk-wasm" / "pkg", WASM_OUT)
 if temporary:

--- a/scripts/build-rynk-wasm.py
+++ b/scripts/build-rynk-wasm.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 # Keep REV in step with the rmk pins in qemu/Cargo.toml and src-tauri/Cargo.toml —
 # firmware and wasm client must come from one protocol commit.
-URL, REV = "https://github.com/rmk-rs/rmk.git", "65df15775026bad1189139613ee3d338139bec3d"
+URL, REV = "https://github.com/rmk-rs/rmk.git", "2ca24ad65bd15ee73073df84d47f4a3a17f91fbb"
 ROOT = Path(__file__).resolve().parent.parent
 WASM_OUT = ROOT / "src" / "rynk" / "wasm"
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -48,6 +48,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +173,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
+name = "bitfield-struct"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ca6739863c590881f038d033a146c51ddae239186a4327014839fd864f44ed5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,49 +209,64 @@ dependencies = [
 
 [[package]]
 name = "block2"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
-dependencies = [
- "objc2 0.5.2",
-]
-
-[[package]]
-name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
- "objc2 0.6.4",
+ "objc2",
 ]
 
 [[package]]
-name = "bluez-async"
-version = "0.8.2"
+name = "bluer"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84ae4213cc2a8dc663acecac67bbdad05142be4d8ef372b6903abf878b0c690a"
+checksum = "aed7969360669bf94a0f4b5e478a98ce0cdde2f9e4a26cecef5fcee53ab6e373"
 dependencies = [
- "bitflags 2.13.1",
- "bluez-generated",
+ "custom_debug",
  "dbus",
+ "dbus-crossroads",
  "dbus-tokio",
+ "displaydoc",
  "futures",
- "itertools",
+ "hex",
+ "lazy_static",
+ "libc",
  "log",
+ "macaddr",
+ "nix",
+ "num-derive",
+ "num-traits",
+ "pin-project",
  "serde",
- "serde-xml-rs",
- "thiserror 2.0.19",
+ "serde_json",
+ "strum 0.25.0",
  "tokio",
+ "tokio-stream",
  "uuid",
 ]
 
 [[package]]
-name = "bluez-generated"
-version = "0.4.0"
+name = "bluest"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9676783265eadd6f11829982792c6f303f3854d014edfba384685dcf237dd062"
+checksum = "a0c911a419028965c201759adadc1b556d1ee50eb2dfcceec3acb765c80e96f6"
 dependencies = [
- "dbus",
+ "async-broadcast",
+ "async-channel",
+ "async-trait",
+ "bluer",
+ "dispatch2",
+ "futures-channel",
+ "futures-core",
+ "futures-lite",
+ "java-spaghetti",
+ "objc2",
+ "objc2-core-bluetooth",
+ "objc2-foundation",
+ "tokio",
+ "tracing",
+ "uuid",
+ "windows 0.48.0",
 ]
 
 [[package]]
@@ -219,33 +297,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
  "tinyvec",
-]
-
-[[package]]
-name = "btleplug"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c3264dbe2c8e29381e4e95aa2d2783ad0b9192b511240f3755b7e5e3cee87e"
-dependencies = [
- "async-trait",
- "bitflags 2.13.1",
- "bluez-async",
- "dashmap",
- "dbus",
- "futures",
- "jni 0.19.0",
- "log",
- "objc2 0.5.2",
- "objc2-core-bluetooth",
- "objc2-foundation 0.2.2",
- "once_cell",
- "static_assertions",
- "thiserror 2.0.19",
- "tokio",
- "tokio-stream",
- "uuid",
- "windows 0.62.2",
- "windows-future 0.3.2",
 ]
 
 [[package]]
@@ -386,12 +437,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "cfg_aliases"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
-
-[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -404,6 +449,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,6 +465,64 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "config"
+version = "0.15.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b85f248a4de22d204ceabc6299d89d2c70fbd7f09fea53c06c852369652d8139"
+dependencies = [
+ "async-trait",
+ "convert_case",
+ "json5",
+ "pathdiff",
+ "ron",
+ "rust-ini",
+ "serde-untagged",
+ "serde_core",
+ "serde_json",
+ "toml 1.1.3+spec-1.1.0",
+ "winnow 1.0.4",
+ "yaml-rust2",
+]
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -482,6 +594,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,6 +613,12 @@ name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -546,6 +670,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
+name = "custom_debug"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89e0ae2c2a42be29595d05c50e3ce6096c0698a97e021c3289790f0750cc8e2"
+dependencies = [
+ "custom_debug_derive",
+]
+
+[[package]]
+name = "custom_debug_derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a9f3941234c9f62ceaa2782974827749de9b0a8a6487275a278da068e1baf7"
+dependencies = [
+ "proc-macro2",
+ "syn 1.0.109",
+ "synstructure 0.12.6",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,20 +724,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "6.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "dbus"
 version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,6 +734,15 @@ dependencies = [
  "libc",
  "libdbus-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-crossroads"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64bff0bd181fba667660276c6b7ebdc50cff37ce593e7adf9e734f89c8f444e8"
+dependencies = [
+ "dbus",
 ]
 
 [[package]]
@@ -675,7 +814,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -685,9 +824,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.13.1",
- "block2 0.6.2",
+ "block2",
  "libc",
- "objc2 0.6.4",
+ "objc2",
 ]
 
 [[package]]
@@ -722,6 +861,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -791,10 +939,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
-name = "either"
-version = "1.16.0"
+name = "embassy-futures"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "dc2d050bdc5c21e0862a89256ed8029ae6c290a93aecefc73084b3002cdebb01"
+
+[[package]]
+name = "embassy-sync"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bbd85cf5a5ae56bdf26f618364af642d1d0a4e245cdd75cd9aabda382f65a81"
+dependencies = [
+ "cfg-if",
+ "critical-section",
+ "embedded-io-async",
+ "futures-core",
+ "futures-sink",
+ "heapless",
+]
 
 [[package]]
 name = "embed-resource"
@@ -817,6 +979,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "embedded-io"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb1aa714776b75c7e67e1da744b81a129b3ff919c8712b5e1b32252c1f07cc7"
+
+[[package]]
+name = "embedded-io-adapters"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900a1c087f1f7d17cdc84a1290df91521cd90933efa76d68e568385d889f2f4"
+dependencies = [
+ "embedded-io 0.7.1",
+ "embedded-io-async",
+ "tokio",
+]
+
+[[package]]
+name = "embedded-io-async"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2564b9f813c544241430e147d8bc454815ef9ac998878d30cc3055449f7fd4c0"
+dependencies = [
+ "embedded-io 0.7.1",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -831,6 +1040,36 @@ dependencies = [
  "serde",
  "serde_core",
  "typeid",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -871,7 +1110,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -969,6 +1208,16 @@ name = "futures-io"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+
+[[package]]
+name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1302,6 +1551,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1315,9 +1573,38 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "heapless"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
+dependencies = [
+ "hash32",
+ "serde_core",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -1606,9 +1893,9 @@ dependencies = [
 
 [[package]]
 name = "io-kit-sys"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617ee6cf8e3f66f3b4ea67a4058564628cde41901316e19f559e14c7c72c5e7b"
+checksum = "06d3a048d09fbb6597dbf7c69f40d14df4a49487db1487191618c893fc3b1c26"
 dependencies = [
  "core-foundation-sys",
  "mach2",
@@ -1621,19 +1908,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "java-spaghetti"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b180a691471c73a518003db62d51c77bfe987a1f143385159647788f251b82"
+dependencies = [
+ "jni-sys 0.4.1",
+]
 
 [[package]]
 name = "javascriptcore-rs"
@@ -1656,20 +1943,6 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
-]
-
-[[package]]
-name = "jni"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
-dependencies = [
- "cesu8",
- "combine",
- "jni-sys 0.3.1",
- "log",
- "thiserror 1.0.69",
- "walkdir",
 ]
 
 [[package]]
@@ -1740,6 +2013,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
 name = "jsonptr"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1759,6 +2043,12 @@ dependencies = [
  "serde",
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libappindicator"
@@ -1819,6 +2109,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1840,10 +2136,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
-name = "mach2"
-version = "0.4.3"
+name = "macaddr"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+checksum = "baee0bbc17ce759db233beb01648088061bf678383130602a298e6998eedb2d8"
+
+[[package]]
+name = "mach2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
 dependencies = [
  "libc",
 ]
@@ -1891,27 +2193,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
- "log",
  "wasi",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "mio-serial"
-version = "5.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d4ba3f20276f21b7cad3f1b54c97489cf096a3894fd627cc6951cb3abdd4c60"
-dependencies = [
- "log",
- "mio",
- "nix 0.31.3",
- "serialport",
  "windows-sys 0.61.2",
 ]
 
@@ -1925,10 +2222,10 @@ dependencies = [
  "dpi",
  "gtk",
  "keyboard-types",
- "objc2 0.6.4",
+ "objc2",
  "objc2-app-kit",
  "objc2-core-foundation",
- "objc2-foundation 0.3.2",
+ "objc2-foundation",
  "once_cell",
  "png 0.18.1",
  "serde",
@@ -1968,24 +2265,12 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
-version = "0.26.4"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
-]
-
-[[package]]
-name = "nix"
-version = "0.31.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
- "cfg_aliases",
  "libc",
 ]
 
@@ -1994,6 +2279,17 @@ name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "num-traits"
@@ -2027,19 +2323,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc-sys"
-version = "0.3.5"
+name = "nusb"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
-
-[[package]]
-name = "objc2"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+checksum = "18ef13beb3b3a8fc16fd7aea912ebd3d45dde00a9a5b968d0742297468065845"
 dependencies = [
- "objc-sys",
- "objc2-encode",
+ "core-foundation",
+ "core-foundation-sys",
+ "futures-core",
+ "io-kit-sys",
+ "js-sys",
+ "linux-raw-sys",
+ "log",
+ "once_cell",
+ "rustix",
+ "slab",
+ "tokio",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2059,10 +2362,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.13.1",
- "block2 0.6.2",
- "objc2 0.6.4",
+ "block2",
+ "objc2",
  "objc2-core-foundation",
- "objc2-foundation 0.3.2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2072,19 +2375,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
  "bitflags 2.13.1",
- "objc2 0.6.4",
- "objc2-foundation 0.3.2",
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
 name = "objc2-core-bluetooth"
-version = "0.2.2"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a644b62ffb826a5277f536cf0f701493de420b13d40e700c452c36567771111"
+checksum = "79b30b9eacc37434a61377866f68b27acef9fa5496f25cc9ca8b2549032e0394"
 dependencies = [
  "bitflags 2.13.1",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2093,8 +2398,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
- "objc2 0.6.4",
- "objc2-foundation 0.3.2",
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2105,7 +2410,7 @@ checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.13.1",
  "dispatch2",
- "objc2 0.6.4",
+ "objc2",
 ]
 
 [[package]]
@@ -2116,7 +2421,7 @@ checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.13.1",
  "dispatch2",
- "objc2 0.6.4",
+ "objc2",
  "objc2-core-foundation",
  "objc2-io-surface",
 ]
@@ -2127,8 +2432,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
 dependencies = [
- "objc2 0.6.4",
- "objc2-foundation 0.3.2",
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2137,8 +2442,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
 dependencies = [
- "objc2 0.6.4",
- "objc2-foundation 0.3.2",
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2148,7 +2453,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
  "bitflags 2.13.1",
- "objc2 0.6.4",
+ "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
 ]
@@ -2170,25 +2475,14 @@ dependencies = [
 
 [[package]]
 name = "objc2-foundation"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
-dependencies = [
- "bitflags 2.13.1",
- "block2 0.5.1",
- "libc",
- "objc2 0.5.2",
-]
-
-[[package]]
-name = "objc2-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.1",
- "block2 0.6.2",
- "objc2 0.6.4",
+ "block2",
+ "libc",
+ "objc2",
  "objc2-core-foundation",
 ]
 
@@ -2199,7 +2493,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
  "bitflags 2.13.1",
- "objc2 0.6.4",
+ "objc2",
  "objc2-core-foundation",
 ]
 
@@ -2210,9 +2504,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
  "bitflags 2.13.1",
- "objc2 0.6.4",
+ "objc2",
  "objc2-core-foundation",
- "objc2-foundation 0.3.2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2222,8 +2516,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.13.1",
- "block2 0.6.2",
- "objc2 0.6.4",
+ "block2",
+ "objc2",
  "objc2-cloud-kit",
  "objc2-core-data",
  "objc2-core-foundation",
@@ -2231,7 +2525,7 @@ dependencies = [
  "objc2-core-image",
  "objc2-core-location",
  "objc2-core-text",
- "objc2-foundation 0.3.2",
+ "objc2-foundation",
  "objc2-quartz-core",
  "objc2-user-notifications",
 ]
@@ -2242,8 +2536,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
 dependencies = [
- "objc2 0.6.4",
- "objc2-foundation 0.3.2",
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2253,11 +2547,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
 dependencies = [
  "bitflags 2.13.1",
- "block2 0.6.2",
- "objc2 0.6.4",
+ "block2",
+ "objc2",
  "objc2-app-kit",
  "objc2-core-foundation",
- "objc2-foundation 0.3.2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2271,6 +2565,16 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "pango"
@@ -2298,6 +2602,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2321,10 +2631,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "phf"
@@ -2380,6 +2744,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2414,7 +2798,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -2427,7 +2811,31 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
+]
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "postcard-derive",
+ "serde",
+]
+
+[[package]]
+name = "postcard-derive"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0232bd009a197ceec9cc881ba46f727fcd8060a2d8d6a9dde7a69030a6fe2bb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2653,18 +3061,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmk-config"
+version = "0.6.1"
+source = "git+https://github.com/rmk-rs/rmk.git?rev=2ca24ad65bd15ee73073df84d47f4a3a17f91fbb#2ca24ad65bd15ee73073df84d47f4a3a17f91fbb"
+dependencies = [
+ "config",
+ "miniz_oxide 0.9.1",
+ "once_cell",
+ "paste",
+ "pest",
+ "pest_derive",
+ "postcard",
+ "serde",
+ "serde-inline-default",
+ "toml 1.1.3+spec-1.1.0",
+]
+
+[[package]]
 name = "rmk-gui"
 version = "0.1.0"
 dependencies = [
- "btleplug",
+ "rynk",
+ "rynk-ble",
+ "rynk-usb",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
  "tokio",
- "tokio-serial",
- "tokio-stream",
  "uuid",
+]
+
+[[package]]
+name = "rmk-types"
+version = "0.2.2"
+source = "git+https://github.com/rmk-rs/rmk.git?rev=2ca24ad65bd15ee73073df84d47f4a3a17f91fbb#2ca24ad65bd15ee73073df84d47f4a3a17f91fbb"
+dependencies = [
+ "bitfield-struct",
+ "cobs",
+ "heapless",
+ "postcard",
+ "rmk-config",
+ "serde",
+ "strum 0.28.0",
+ "toml 1.1.3+spec-1.1.0",
+]
+
+[[package]]
+name = "ron"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81116b9531d61eabc41aeb228e4b6b2435bcca3233b98cf3b3077d4e6e9debb3"
+dependencies = [
+ "bitflags 2.13.1",
+ "once_cell",
+ "serde",
+ "serde_derive",
+ "typeid",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -2683,10 +3147,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "rynk"
+version = "0.1.0"
+source = "git+https://github.com/rmk-rs/rmk.git?rev=2ca24ad65bd15ee73073df84d47f4a3a17f91fbb#2ca24ad65bd15ee73073df84d47f4a3a17f91fbb"
+dependencies = [
+ "critical-section",
+ "embassy-futures",
+ "embassy-sync",
+ "embedded-io-async",
+ "heapless",
+ "log",
+ "postcard",
+ "rmk-config",
+ "rmk-types",
+ "serde",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "rynk-ble"
+version = "0.1.0"
+source = "git+https://github.com/rmk-rs/rmk.git?rev=2ca24ad65bd15ee73073df84d47f4a3a17f91fbb#2ca24ad65bd15ee73073df84d47f4a3a17f91fbb"
+dependencies = [
+ "async-stream",
+ "bluest",
+ "futures-util",
+ "log",
+ "rynk",
+ "tokio",
+]
+
+[[package]]
+name = "rynk-usb"
+version = "0.1.0"
+source = "git+https://github.com/rmk-rs/rmk.git?rev=2ca24ad65bd15ee73073df84d47f4a3a17f91fbb#2ca24ad65bd15ee73073df84d47f4a3a17f91fbb"
+dependencies = [
+ "embedded-io-adapters",
+ "nusb",
+ "rynk",
+]
 
 [[package]]
 name = "same-file"
@@ -2794,6 +3312,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-inline-default"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a024ee82abb97858516d2539fa845e6ef82ef57fdede6833ca24ed26425b614"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.2",
+]
+
+[[package]]
 name = "serde-untagged"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2803,18 +3332,6 @@ dependencies = [
  "serde",
  "serde_core",
  "typeid",
-]
-
-[[package]]
-name = "serde-xml-rs"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2215ce3e6a77550b80a1c37251b7d294febaf42e36e21b7b411e0bf54d540d"
-dependencies = [
- "log",
- "serde",
- "thiserror 2.0.19",
- "xml",
 ]
 
 [[package]]
@@ -2945,24 +3462,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serialport"
-version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4d91116f97173694f1642263b2ff837f80d933aa837e2314969f6728f661df3"
-dependencies = [
- "bitflags 2.13.1",
- "cfg-if",
- "core-foundation",
- "core-foundation-sys",
- "io-kit-sys",
- "mach2",
- "nix 0.26.4",
- "scopeguard",
- "unescaper",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "servo_arc"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3031,10 +3530,10 @@ dependencies = [
  "bytemuck",
  "js-sys",
  "ndk",
- "objc2 0.6.4",
+ "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation 0.3.2",
+ "objc2-foundation",
  "objc2-quartz-core",
  "raw-window-handle",
  "redox_syscall",
@@ -3077,12 +3576,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "string_cache"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3113,6 +3606,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros 0.25.3",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3130,6 +3666,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -3166,6 +3703,18 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "unicode-xid",
+]
+
+[[package]]
+name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
@@ -3195,7 +3744,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
  "bitflags 2.13.1",
- "block2 0.6.2",
+ "block2",
  "core-foundation",
  "core-graphics",
  "crossbeam-channel",
@@ -3206,14 +3755,14 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni 0.21.1",
+ "jni",
  "libc",
  "log",
  "ndk",
  "ndk-sys",
- "objc2 0.6.4",
+ "objc2",
  "objc2-app-kit",
- "objc2-foundation 0.3.2",
+ "objc2-foundation",
  "objc2-ui-kit",
  "once_cell",
  "parking_lot",
@@ -3262,14 +3811,14 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "jni 0.21.1",
+ "jni",
  "libc",
  "log",
  "mime",
  "muda",
- "objc2 0.6.4",
+ "objc2",
  "objc2-app-kit",
- "objc2-foundation 0.3.2",
+ "objc2-foundation",
  "objc2-ui-kit",
  "objc2-web-kit",
  "percent-encoding",
@@ -3368,8 +3917,8 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni 0.21.1",
- "objc2 0.6.4",
+ "jni",
+ "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
  "raw-window-handle",
@@ -3391,9 +3940,9 @@ checksum = "4e6fac707727b7a2f48e4ded90976324267371073edbb415ffb73bb0458d203f"
 dependencies = [
  "gtk",
  "http",
- "jni 0.21.1",
+ "jni",
  "log",
- "objc2 0.6.4",
+ "objc2",
  "objc2-app-kit",
  "once_cell",
  "percent-encoding",
@@ -3440,7 +3989,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.19",
- "toml 1.1.3+spec-1.1.0",
+ "toml 0.9.12+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",
@@ -3538,6 +4087,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3589,21 +4147,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-serial"
-version = "5.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd00f5f8b1e01c3e5afccd9e42ed80c2ad2df6d007877f29f8592c62e69cd116"
-dependencies = [
- "cfg-if",
- "futures-core",
- "futures-sink",
- "log",
- "mio-serial",
- "serialport",
- "tokio",
-]
-
-[[package]]
 name = "tokio-stream"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3612,7 +4155,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util",
 ]
 
 [[package]]
@@ -3822,11 +4364,11 @@ dependencies = [
  "dirs",
  "libappindicator",
  "muda",
- "objc2 0.6.4",
+ "objc2",
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation 0.3.2",
+ "objc2-foundation",
  "once_cell",
  "png 0.18.1",
  "serde",
@@ -3853,13 +4395,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
-name = "unescaper"
-version = "0.1.10"
+name = "ucd-trie"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7285e83a80ce76f5e7bce79fa41f68d78ba62d1003cf27bf748ab24413808cf4"
-dependencies = [
- "thiserror 2.0.19",
-]
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unic-char-property"
@@ -3913,6 +4452,12 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "url"
@@ -4167,8 +4712,8 @@ dependencies = [
  "webview2-com-sys",
  "windows 0.61.3",
  "windows-core 0.61.2",
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
 ]
 
 [[package]]
@@ -4215,7 +4760,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4230,13 +4775,24 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9bec5a31f3f9362f2258fd0e9c9dd61a9ca432e7306cc78c444258f0dce9a9c"
 dependencies = [
- "objc2 0.6.4",
+ "objc2",
  "objc2-app-kit",
  "objc2-core-foundation",
- "objc2-foundation 0.3.2",
+ "objc2-foundation",
  "raw-window-handle",
  "windows-sys 0.59.0",
  "windows-version",
+]
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-implement 0.48.0",
+ "windows-interface 0.48.0",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4245,23 +4801,11 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections 0.2.0",
+ "windows-collections",
  "windows-core 0.61.2",
- "windows-future 0.2.1",
+ "windows-future",
  "windows-link 0.1.3",
- "windows-numerics 0.2.0",
-]
-
-[[package]]
-name = "windows"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
-dependencies = [
- "windows-collections 0.3.2",
- "windows-core 0.62.2",
- "windows-future 0.3.2",
- "windows-numerics 0.3.1",
+ "windows-numerics",
 ]
 
 [[package]]
@@ -4274,22 +4818,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-collections"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
-dependencies = [
- "windows-core 0.62.2",
-]
-
-[[package]]
 name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -4301,8 +4836,8 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
@@ -4316,18 +4851,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading 0.1.0",
+ "windows-threading",
 ]
 
 [[package]]
-name = "windows-future"
-version = "0.3.2"
+name = "windows-implement"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+checksum = "5e2ee588991b9e7e6c8338edf3333fbe4da35dc72092643958ebb43f0ab2c49c"
 dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
- "windows-threading 0.2.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4339,6 +4874,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6fb8df20c9bcaa8ad6ab513f7b40104840c8867d5751126e4df3b08388d0cc7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4372,16 +4918,6 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-numerics"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
-dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4431,15 +4967,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -4473,6 +5000,21 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -4497,15 +5039,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-threading"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
-dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
 name = "windows-version"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4522,6 +5055,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4534,6 +5073,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4543,6 +5088,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4564,6 +5115,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4573,6 +5130,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4588,6 +5151,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4597,6 +5166,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4657,7 +5232,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "186f9871daa55fd9c016578b810d149de58367113db7fb72b462d2323ce19514"
 dependencies = [
  "base64 0.22.1",
- "block2 0.6.2",
+ "block2",
  "cookie",
  "crossbeam-channel",
  "dirs",
@@ -4668,13 +5243,13 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni 0.21.1",
+ "jni",
  "libc",
  "ndk",
- "objc2 0.6.4",
+ "objc2",
  "objc2-app-kit",
  "objc2-core-foundation",
- "objc2-foundation 0.3.2",
+ "objc2-foundation",
  "objc2-ui-kit",
  "objc2-web-kit",
  "once_cell",
@@ -4716,10 +5291,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "xml"
-version = "1.3.0"
+name = "yaml-rust2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "636f85e5ca6488e96401b61eb7de54f4e44755c988af0f52cf90230c312a1a89"
+checksum = "631a50d867fafb7093e709d75aaee9e0e0d5deb934021fcea25ac2fe09edc51e"
+dependencies = [
+ "arraydeque",
+ "encoding_rs",
+ "hashlink",
+]
 
 [[package]]
 name = "yoke"
@@ -4741,7 +5321,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
- "synstructure",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
@@ -4762,7 +5342,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
- "synstructure",
+ "synstructure 0.13.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1625,6 +1625,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hidapi"
+version = "2.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c78dadfc12f865bc3fcac3897e64533b930737ceb9ef245c8277de98d0b010e9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "pkg-config",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3063,7 +3076,7 @@ dependencies = [
 [[package]]
 name = "rmk-config"
 version = "0.6.1"
-source = "git+https://github.com/rmk-rs/rmk.git?rev=2ca24ad65bd15ee73073df84d47f4a3a17f91fbb#2ca24ad65bd15ee73073df84d47f4a3a17f91fbb"
+source = "git+https://github.com/rmk-rs/rmk.git?rev=0fd8785d669d2139d0a0b75f2441a4d4b463b01a#0fd8785d669d2139d0a0b75f2441a4d4b463b01a"
 dependencies = [
  "config",
  "miniz_oxide 0.9.1",
@@ -3081,6 +3094,7 @@ dependencies = [
 name = "rmk-gui"
 version = "0.1.0"
 dependencies = [
+ "hidapi",
  "rynk",
  "rynk-ble",
  "rynk-usb",
@@ -3095,7 +3109,7 @@ dependencies = [
 [[package]]
 name = "rmk-types"
 version = "0.2.2"
-source = "git+https://github.com/rmk-rs/rmk.git?rev=2ca24ad65bd15ee73073df84d47f4a3a17f91fbb#2ca24ad65bd15ee73073df84d47f4a3a17f91fbb"
+source = "git+https://github.com/rmk-rs/rmk.git?rev=0fd8785d669d2139d0a0b75f2441a4d4b463b01a#0fd8785d669d2139d0a0b75f2441a4d4b463b01a"
 dependencies = [
  "bitfield-struct",
  "cobs",
@@ -3168,7 +3182,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 [[package]]
 name = "rynk"
 version = "0.1.0"
-source = "git+https://github.com/rmk-rs/rmk.git?rev=2ca24ad65bd15ee73073df84d47f4a3a17f91fbb#2ca24ad65bd15ee73073df84d47f4a3a17f91fbb"
+source = "git+https://github.com/rmk-rs/rmk.git?rev=0fd8785d669d2139d0a0b75f2441a4d4b463b01a#0fd8785d669d2139d0a0b75f2441a4d4b463b01a"
 dependencies = [
  "critical-section",
  "embassy-futures",
@@ -3186,7 +3200,7 @@ dependencies = [
 [[package]]
 name = "rynk-ble"
 version = "0.1.0"
-source = "git+https://github.com/rmk-rs/rmk.git?rev=2ca24ad65bd15ee73073df84d47f4a3a17f91fbb#2ca24ad65bd15ee73073df84d47f4a3a17f91fbb"
+source = "git+https://github.com/rmk-rs/rmk.git?rev=0fd8785d669d2139d0a0b75f2441a4d4b463b01a#0fd8785d669d2139d0a0b75f2441a4d4b463b01a"
 dependencies = [
  "async-stream",
  "bluest",
@@ -3199,7 +3213,7 @@ dependencies = [
 [[package]]
 name = "rynk-usb"
 version = "0.1.0"
-source = "git+https://github.com/rmk-rs/rmk.git?rev=2ca24ad65bd15ee73073df84d47f4a3a17f91fbb#2ca24ad65bd15ee73073df84d47f4a3a17f91fbb"
+source = "git+https://github.com/rmk-rs/rmk.git?rev=0fd8785d669d2139d0a0b75f2441a4d4b463b01a#0fd8785d669d2139d0a0b75f2441a4d4b463b01a"
 dependencies = [
  "embedded-io-adapters",
  "nusb",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,9 +25,12 @@ tokio = { version = "1.53.1", features = [
 # peers. Neither is reimplemented here — discovery rules belong with the
 # protocol. Pinned by rev: the firmware fixture and the wasm client must speak
 # the same protocol commit, so all three rmk pins move together.
-rynk = { git = "https://github.com/rmk-rs/rmk.git", rev = "2ca24ad65bd15ee73073df84d47f4a3a17f91fbb" }
-rynk-usb = { git = "https://github.com/rmk-rs/rmk.git", rev = "2ca24ad65bd15ee73073df84d47f4a3a17f91fbb" }
-rynk-ble = { git = "https://github.com/rmk-rs/rmk.git", rev = "2ca24ad65bd15ee73073df84d47f4a3a17f91fbb" }
+rynk = { git = "https://github.com/rmk-rs/rmk.git", rev = "0fd8785d669d2139d0a0b75f2441a4d4b463b01a" }
+rynk-usb = { git = "https://github.com/rmk-rs/rmk.git", rev = "0fd8785d669d2139d0a0b75f2441a4d4b463b01a" }
+rynk-ble = { git = "https://github.com/rmk-rs/rmk.git", rev = "0fd8785d669d2139d0a0b75f2441a4d4b463b01a" }
+# Vial keyboards live on a raw-HID vendor page, which nusb cannot claim on
+# Windows — hidapi is the portable route to them (USB and OS-bonded BLE).
+hidapi = "2.6"
 uuid = { version = "1.24.0", features = [ "v4" ] }
 
 [lints.clippy]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,9 +25,9 @@ tokio = { version = "1.53.1", features = [
 # peers. Neither is reimplemented here — discovery rules belong with the
 # protocol. Pinned by rev: the firmware fixture and the wasm client must speak
 # the same protocol commit, so all three rmk pins move together.
-rynk = { git = "https://github.com/rmk-rs/rmk.git", rev = "65df15775026bad1189139613ee3d338139bec3d" }
-rynk-usb = { git = "https://github.com/rmk-rs/rmk.git", rev = "65df15775026bad1189139613ee3d338139bec3d" }
-rynk-ble = { git = "https://github.com/rmk-rs/rmk.git", rev = "65df15775026bad1189139613ee3d338139bec3d" }
+rynk = { git = "https://github.com/rmk-rs/rmk.git", rev = "2ca24ad65bd15ee73073df84d47f4a3a17f91fbb" }
+rynk-usb = { git = "https://github.com/rmk-rs/rmk.git", rev = "2ca24ad65bd15ee73073df84d47f4a3a17f91fbb" }
+rynk-ble = { git = "https://github.com/rmk-rs/rmk.git", rev = "2ca24ad65bd15ee73073df84d47f4a3a17f91fbb" }
 uuid = { version = "1.24.0", features = [ "v4" ] }
 
 [lints.clippy]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 use tauri::Builder;
 use tokio::sync::Mutex;
-use transport::{Session, ble, tcp, usb};
+use transport::{Session, ble, hid, tcp, usb};
 
 fn main() {
     Builder::default()
@@ -15,6 +15,7 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             usb::rynk_discover_usb, ble::rynk_discover_ble, tcp::rynk_discover_tcp,
             usb::rynk_connect_usb, ble::rynk_connect_ble, tcp::rynk_connect_tcp,
+            hid::vial_discover_hid, hid::vial_connect_hid,
             transport::rynk_send, transport::rynk_recv, transport::rynk_close,
             transport::rynk_close_all,
         ])

--- a/src-tauri/src/transport/hid.rs
+++ b/src-tauri/src/transport/hid.rs
@@ -1,0 +1,162 @@
+//! Native Vial transport: raw HID on the classic 0xFF60 vendor page, via
+//! `hidapi`. Covers USB keyboards and OS-bonded Bluetooth ones alike — both
+//! surface from the same enumeration.
+//!
+//! `HidDevice` is `Send` but not `Sync`, so one thread owns the handle and the
+//! pump is shaped for Vial's lockstep instead of the tokio select the byte
+//! transports use: idle means blocked on the command channel (a send wakes it
+//! instantly, no poll latency), and a blocking `read` only ever runs right
+//! after a request went out. A device that stays silent for the whole reply
+//! window reads as a dead link — the per-exchange watchdog the protocol
+//! itself doesn't have.
+
+use hidapi::{BusType, HidApi, HidDevice};
+use serde::Serialize;
+use tauri::State;
+use tokio::sync::mpsc;
+
+use super::{insert_session, SessionCmd, Sessions};
+
+const VIAL_USAGE_PAGE: u16 = 0xFF60;
+const VIAL_USAGE: u16 = 0x61;
+/// One request or response report; id 0 goes in front of writes.
+const REPORT_SIZE: usize = 32;
+/// Total silence budget after a request, sliced so a close stays responsive.
+const REPLY_TIMEOUT_MS: i32 = 3_000;
+const REPLY_SLICE_MS: i32 = 100;
+
+#[derive(Serialize)]
+pub struct VialHidDeviceInfo {
+    pub id: String,
+    pub name: String,
+    pub bluetooth: bool,
+}
+
+fn label(info: &hidapi::DeviceInfo) -> String {
+    match info.product_string() {
+        Some(name) if !name.trim().is_empty() => name.to_string(),
+        _ => format!("HID {:04x}:{:04x}", info.vendor_id(), info.product_id()),
+    }
+}
+
+/// Enumerate Vial interfaces. The interface path is the id: unique per
+/// interface and stable while the device stays attached, and `open_path` is
+/// the one open that cannot grab a sibling interface by mistake.
+#[tauri::command]
+pub async fn vial_discover_hid() -> Result<Vec<VialHidDeviceInfo>, String> {
+    tokio::task::spawn_blocking(|| {
+        let api = HidApi::new().map_err(|e| e.to_string())?;
+        Ok(api
+            .device_list()
+            .filter(|d| d.usage_page() == VIAL_USAGE_PAGE && d.usage() == VIAL_USAGE)
+            .map(|d| VialHidDeviceInfo {
+                id: d.path().to_string_lossy().into_owned(),
+                name: label(d),
+                bluetooth: matches!(d.bus_type(), BusType::Bluetooth),
+            })
+            .collect())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn vial_connect_hid(id: String, sessions: State<'_, Sessions>) -> Result<String, String> {
+    let device = tokio::task::spawn_blocking(move || {
+        let api = HidApi::new().map_err(|e| e.to_string())?;
+        let path = std::ffi::CString::new(id).map_err(|e| e.to_string())?;
+        api.open_path(&path).map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| e.to_string())??;
+
+    let (cmd_tx, cmd_rx) = mpsc::channel::<SessionCmd>(64);
+    let (data_tx, data_rx) = mpsc::channel::<Vec<u8>>(64);
+    std::thread::spawn(move || pump(device, cmd_rx, data_tx));
+    Ok(insert_session(&sessions, cmd_tx, data_rx).await)
+}
+
+/// Forward whatever already sits in the OS buffer — stale replies from a
+/// desynced session the client's echo check will discard. `Ok(false)` when the
+/// device errored (and EOF was sent).
+fn forward_pending(device: &HidDevice, data_tx: &mpsc::Sender<Vec<u8>>) -> bool {
+    let mut buf = [0u8; REPORT_SIZE];
+    loop {
+        match device.read_timeout(&mut buf, 0) {
+            Ok(0) => return true,
+            Ok(n) => {
+                if data_tx.blocking_send(buf[..n].to_vec()).is_err() {
+                    return false;
+                }
+            }
+            Err(_) => {
+                let _ = data_tx.blocking_send(Vec::new());
+                return false;
+            }
+        }
+    }
+}
+
+/// A close queued behind the reply wait; a stray send here cannot happen —
+/// the protocol client is lockstep and only sends after the reply lands.
+fn close_requested(cmd_rx: &mut mpsc::Receiver<SessionCmd>) -> bool {
+    loop {
+        match cmd_rx.try_recv() {
+            Ok(SessionCmd::Close) | Err(mpsc::error::TryRecvError::Disconnected) => return true,
+            Ok(SessionCmd::Send(_, _)) => continue,
+            Err(mpsc::error::TryRecvError::Empty) => return false,
+        }
+    }
+}
+
+fn pump(device: HidDevice, mut cmd_rx: mpsc::Receiver<SessionCmd>, data_tx: mpsc::Sender<Vec<u8>>) {
+    let mut buf = [0u8; REPORT_SIZE];
+    loop {
+        match cmd_rx.blocking_recv() {
+            Some(SessionCmd::Send(data, ack)) => {
+                if !forward_pending(&device, &data_tx) {
+                    let _ = ack.send(());
+                    return;
+                }
+                // hidapi wants the report id in front; the device's collection
+                // uses id 0.
+                let mut report = Vec::with_capacity(data.len() + 1);
+                report.push(0);
+                report.extend_from_slice(&data);
+                if device.write(&report).is_err() {
+                    let _ = ack.send(());
+                    let _ = data_tx.blocking_send(Vec::new());
+                    return;
+                }
+                let _ = ack.send(());
+                let mut waited = 0;
+                loop {
+                    match device.read_timeout(&mut buf, REPLY_SLICE_MS) {
+                        Ok(0) => {
+                            waited += REPLY_SLICE_MS;
+                            if close_requested(&mut cmd_rx) {
+                                return;
+                            }
+                            if waited >= REPLY_TIMEOUT_MS {
+                                let _ = data_tx.blocking_send(Vec::new());
+                                return;
+                            }
+                        }
+                        Ok(n) => {
+                            let _ = data_tx.blocking_send(buf[..n].to_vec());
+                            break;
+                        }
+                        Err(_) => {
+                            let _ = data_tx.blocking_send(Vec::new());
+                            return;
+                        }
+                    }
+                }
+                if !forward_pending(&device, &data_tx) {
+                    return;
+                }
+            }
+            Some(SessionCmd::Close) | None => return,
+        }
+    }
+}

--- a/src-tauri/src/transport/mod.rs
+++ b/src-tauri/src/transport/mod.rs
@@ -1,4 +1,5 @@
 pub mod ble;
+pub mod hid;
 pub mod tcp;
 pub mod usb;
 

--- a/src/components/Board.svelte
+++ b/src/components/Board.svelte
@@ -14,9 +14,15 @@
     selected: { row: number, col: number } | null
     onselect: (row: number, col: number) => void
     onassign: (row: number, col: number) => void
+    /// When set, encoders become clickable and open their editor.
+    onencoder?: (id: number) => void
+    /// Matrix cells to draw as physically held (the tester's live bitmap).
+    pressed?: ReadonlySet<string>
+    /// Cells to dot-mark — the tester's "seen pressed at least once".
+    marked?: ReadonlySet<string>
   }
 
-  const { variant, caps, layer, layerIndex, selected, onselect, onassign }: Props = $props()
+  const { variant, caps, layer, layerIndex, selected, onselect, onassign, onencoder, pressed, marked }: Props = $props()
 
   /// The design's key unit; the board is then scaled to whatever space it gets.
   const UNIT = 60
@@ -67,31 +73,40 @@
           {originY}
           unit={UNIT}
           selected={selected?.row === key.row && selected?.col === key.col}
-          overridden={layerIndex > 0 && action !== 'Transparent'}
+          overridden={(layerIndex > 0 && action !== 'Transparent')
+            || (marked?.has(cell(key.row, key.col)) ?? false)}
           dragOver={dragOver === cell(key.row, key.col)}
+          pressed={pressed?.has(cell(key.row, key.col)) ?? false}
           onclick={() => onselect(key.row, key.col)}
           ondropaction={() => onassign(key.row, key.col)}
           ondragstate={(over) => { dragOver = over ? cell(key.row, key.col) : null }}
         />
       {/each}
 
-      <!-- Encoders are part of the physical layout, so the board shows where
-           they sit; the design has no editor for their actions. -->
       {#each variant.encoders as encoder (encoder.id)}
-        <div
-          class={`
-            absolute flex items-center justify-center rounded-full border
-            border-dashed border-kc-border bg-kc-mod-top text-[10px]
-            font-semibold text-muted-foreground
-          `}
+        <button
+          class={[
+            `
+              absolute flex items-center justify-center rounded-full border
+              border-dashed border-kc-border bg-kc-mod-top text-[10px]
+              font-semibold text-muted-foreground
+            `,
+            onencoder && `
+              cursor-pointer
+              hover:border-brand hover:text-brand-darker
+            `,
+          ]}
           style:left='{(encoder.x - originX - 0.5) * UNIT + 4}px'
           style:top='{(encoder.y - originY - 0.5) * UNIT + 4}px'
           style:width='{UNIT - 8}px'
           style:height='{UNIT - 8}px'
-          title='Encoder {encoder.id}'
+          type='button'
+          disabled={!onencoder}
+          title={onencoder ? `Edit encoder ${encoder.id}` : `Encoder ${encoder.id}`}
+          onclick={() => onencoder?.(encoder.id)}
         >
           E{encoder.id}
-        </div>
+        </button>
       {/each}
     </div>
   </div>

--- a/src/components/EncoderOverlay.svelte
+++ b/src/components/EncoderOverlay.svelte
@@ -1,0 +1,83 @@
+<script lang='ts'>
+  import type { KeyAction } from '../rynk'
+  import Icon from '@iconify/svelte'
+  import { keyActionText } from '../lib/keycode'
+  import { toast } from '../lib/toast.svelte'
+  import { describeKeyboardError, keyboardStore } from '../stores'
+  import KeycodeSelect from './KeycodeSelect.svelte'
+  import Overlay from './ui/Overlay.svelte'
+
+  interface Props {
+    encoder: number
+    layer: number
+    onclose: () => void
+  }
+
+  const { encoder, layer, onclose }: Props = $props()
+
+  type Direction = 'clockwise' | 'counter_clockwise'
+
+  let direction = $state<Direction>('clockwise')
+
+  const caps = $derived(keyboardStore.device?.capabilities)
+  const action = $derived(keyboardStore.config?.encoders[encoder]?.[layer])
+
+  function assign(picked: KeyAction) {
+    const current = action
+    if (!current) return
+    const filled = direction
+    void keyboardStore
+      .setEncoder(encoder, layer, { ...current, [filled]: picked })
+      .match(
+        // Flip to the other direction so CW then CCW is two picks, not four clicks.
+        () => { if (filled === 'clockwise') direction = 'counter_clockwise' },
+        e => toast.error(describeKeyboardError(e)),
+      )
+  }
+
+  const DIRECTIONS = [
+    { value: 'clockwise', label: 'Clockwise', icon: 'lucide:rotate-cw' },
+    { value: 'counter_clockwise', label: 'Counter-clockwise', icon: 'lucide:rotate-ccw' },
+  ] as const satisfies readonly { value: Direction, label: string, icon: string }[]
+</script>
+
+<Overlay
+  title='Encoder {encoder}'
+  subtitle='What each turn direction does on layer {layer}.'
+  {onclose}
+>
+  <div class='flex min-h-0 flex-1 flex-col gap-3'>
+    <div class='flex flex-none items-center gap-2'>
+      {#each DIRECTIONS as dir (dir.value)}
+        {@const on = direction === dir.value}
+        <button
+          class={[
+            `
+              inline-flex h-9 cursor-pointer items-center gap-2 rounded-[10px]
+              border px-3 text-[13px] transition-colors
+            `,
+            on
+              ? `border-brand bg-brand-tint font-bold text-brand-darker`
+              : `
+                border-base-300 bg-base-100 font-semibold text-muted-foreground
+                hover:text-foreground
+              `,
+          ]}
+          type='button'
+          aria-pressed={on}
+          onclick={() => (direction = dir.value)}
+        >
+          <Icon icon={dir.icon} width={15} height={15} />
+          {dir.label}
+          <span class='font-mono text-xs opacity-80'>
+            {action ? keyActionText(action[dir.value]) : ''}
+          </span>
+        </button>
+      {/each}
+    </div>
+
+    <div class='flex min-h-0 flex-1'>
+      <KeycodeSelect {caps} onpick={assign} />
+    </div>
+  </div>
+</Overlay>

--- a/src/components/HoldTapBuilder.svelte
+++ b/src/components/HoldTapBuilder.svelte
@@ -1,7 +1,6 @@
 <script lang='ts'>
   import type { CatalogEntry } from '../lib/keycatalog'
   import type { Action, KeyAction, ModifierCombination } from '../rynk'
-  import Icon from '@iconify/svelte'
   import { asAction } from '../lib/keycatalog'
   import { actionLabel, NO_MODIFIERS } from '../lib/keycode'
   import MiniKey from './MiniKey.svelte'
@@ -14,10 +13,13 @@
     layerCount: number
     /// Morse slots on the firmware; their profiles carry per-key timing.
     morseCount: number
+    /// Lowercased text from the picker's own search box, which filters the tap
+    /// keys while this tab is up rather than leaving the tab for the catalog.
+    query: string
     onpick: (action: KeyAction) => void
   }
 
-  const { taps, layerCount, morseCount, onpick }: Props = $props()
+  const { taps, layerCount, morseCount, query, onpick }: Props = $props()
 
   const MODS = [
     { value: 'left_ctrl', label: 'Ctrl' },
@@ -31,7 +33,6 @@
   let kind = $state<'LT' | 'MT'>('LT')
   let holdLayer = $state(1)
   let holdMod = $state<keyof ModifierCombination>('left_shift')
-  let query = $state('')
 
   const layers = $derived(
     Array.from({ length: Math.max(1, layerCount - 1) }, (_, i) => ({
@@ -51,10 +52,9 @@
   const candidates = $derived(taps.filter(entry => asAction(entry.action) !== null))
 
   const results = $derived.by(() => {
-    const q = query.trim().toLowerCase()
-    if (!q) return candidates.slice(0, LIMIT)
+    if (!query) return candidates.slice(0, LIMIT)
     return candidates
-      .filter(e => e.label.toLowerCase().includes(q) || (e.title ?? '').toLowerCase().includes(q))
+      .filter(e => e.label.toLowerCase().includes(query) || (e.title ?? '').toLowerCase().includes(query))
       .slice(0, LIMIT)
   })
 
@@ -126,22 +126,6 @@
         onchange={v => (profile = Number(v))}
       />
     {/if}
-    <div class='relative ml-auto w-50'>
-      <Icon
-        class='absolute top-[9px] left-2.5 text-muted-foreground'
-        icon='lucide:search'
-        width={14}
-        height={14}
-      />
-      <input
-        class={`
-          h-8 w-full rounded-md border border-input bg-background pr-2.5 pl-8
-          text-[12.5px] text-foreground outline-none
-        `}
-        placeholder='Find tap key…'
-        bind:value={query}
-      />
-    </div>
   </div>
 
   <div class='text-[11.5px] text-muted-foreground'>
@@ -157,6 +141,7 @@
           sub={entry.sub}
           w={1.25}
           title={entry.title ?? entry.label}
+          highlight={query || undefined}
           onpick={() => onpick(build(entry))}
         />
       {/each}

--- a/src/components/HoldTapBuilder.svelte
+++ b/src/components/HoldTapBuilder.svelte
@@ -13,8 +13,7 @@
     layerCount: number
     /// Morse slots on the firmware; their profiles carry per-key timing.
     morseCount: number
-    /// Lowercased text from the picker's own search box, which filters the tap
-    /// keys while this tab is up rather than leaving the tab for the catalog.
+    /// Lowercased text from the picker's own search box — this tab has none of its own.
     query: string
     onpick: (action: KeyAction) => void
   }

--- a/src/components/HoldTapBuilder.svelte
+++ b/src/components/HoldTapBuilder.svelte
@@ -6,15 +6,18 @@
   import { actionLabel, NO_MODIFIERS } from '../lib/keycode'
   import MiniKey from './MiniKey.svelte'
   import Segmented from './ui/Segmented.svelte'
+  import Select from './ui/Select.svelte'
 
   interface Props {
     /// Every plain key the firmware offers; the tap half is picked from these.
     taps: CatalogEntry[]
     layerCount: number
+    /// Morse slots on the firmware; their profiles carry per-key timing.
+    morseCount: number
     onpick: (action: KeyAction) => void
   }
 
-  const { taps, layerCount, onpick }: Props = $props()
+  const { taps, layerCount, morseCount, onpick }: Props = $props()
 
   const MODS = [
     { value: 'left_ctrl', label: 'Ctrl' },
@@ -56,11 +59,21 @@
   })
 
   /// The trailing index selects a morse profile; `0xFF` has no table entry, so
-  /// the firmware falls back to its default timings — what the picker wants.
+  /// the firmware falls back to its default timings.
   const DEFAULT_PROFILE = 0xFF
 
+  let profile = $state(DEFAULT_PROFILE)
+
+  const profiles = $derived([
+    { value: String(DEFAULT_PROFILE), label: 'default' },
+    ...Array.from({ length: morseCount }, (_, i) => ({
+      value: String(i),
+      label: `Morse ${i}`,
+    })),
+  ])
+
   function build(entry: CatalogEntry): KeyAction {
-    return { TapHold: [asAction(entry.action)!, hold, DEFAULT_PROFILE] }
+    return { TapHold: [asAction(entry.action)!, hold, profile] }
   }
 </script>
 
@@ -98,6 +111,19 @@
         value={holdMod}
         height={28}
         onchange={v => (holdMod = v)}
+      />
+    {/if}
+    {#if morseCount > 0}
+      <span class='
+        ml-2 text-xs font-bold tracking-wider text-muted-foreground uppercase
+      '>
+        Timing
+      </span>
+      <Select
+        items={profiles}
+        value={String(profile)}
+        label='Timing profile'
+        onchange={v => (profile = Number(v))}
       />
     {/if}
     <div class='relative ml-auto w-50'>

--- a/src/components/Keycap.svelte
+++ b/src/components/Keycap.svelte
@@ -21,6 +21,8 @@
     /// Marks a key that overrides the layer beneath it.
     overridden?: boolean
     dragOver?: boolean
+    /// Physically held right now — the tester's live highlight.
+    pressed?: boolean
     onclick?: () => void
     ondropaction?: () => void
     ondragstate?: (over: boolean) => void
@@ -38,6 +40,7 @@
     selected = false,
     overridden = false,
     dragOver = false,
+    pressed = false,
     onclick,
     ondropaction,
     ondragstate,
@@ -84,9 +87,11 @@
           `,
           dragOver
             ? 'border-kc-amber-border bg-kc-amber-top'
+            : pressed
+            ? 'border-brand bg-brand-tint-strong text-brand-darker'
             : TINTS[legend.tint],
           selected && 'border-2 border-brand shadow-[0_0_0_3px_var(--kc-ring)]',
-          transparent && !selected && 'opacity-55',
+          transparent && !selected && !pressed && 'opacity-55',
         ]}
         style:border-radius='{radius}px'
         type='button'

--- a/src/components/KeycodeSelect.svelte
+++ b/src/components/KeycodeSelect.svelte
@@ -65,8 +65,8 @@
   const basic = $derived(groups.find(g => g.name === 'Basic')?.entries ?? [])
 
   const needle = $derived(query.trim().toLowerCase())
-  /// Hold-Tap builds an action rather than listing one, so it keeps the header's
-  /// search box for its own tap keys and stays the current tab while typing.
+  /// Hold-Tap has no list to search: the box filters its tap keys instead, so
+  /// typing must not unpin the tab.
   const holdTap = $derived(group === HOLD_TAP)
   const searching = $derived(needle !== '' && !holdTap)
 
@@ -102,8 +102,6 @@
   }
 </script>
 
-<!-- One surface: the categories sit inside the panel above a hairline, rather
-     than on a separate floating bar the keys hang off. -->
 <div
   class={[
     'flex min-h-0 w-full flex-col overflow-hidden',
@@ -117,7 +115,7 @@
     ]}
   >
     <!-- While a catalog search runs no group is current, so the bound value
-         walks off every radio rather than pinning a stale tab on. -->
+         walks off every radio rather than pinning a stale tab. -->
     <RadioGroup.Root
       class='noscroll flex min-w-0 flex-1 gap-0.5 overflow-x-auto'
       orientation='horizontal'

--- a/src/components/KeycodeSelect.svelte
+++ b/src/components/KeycodeSelect.svelte
@@ -167,7 +167,12 @@
       {#if catalog.hid.length === 0}
         <p class='p-2 text-[13px] text-muted-foreground'>Loading keycodes…</p>
       {:else if holdTap}
-        <HoldTapBuilder taps={basic} layerCount={caps?.num_layers ?? 1} {onpick} />
+        <HoldTapBuilder
+          taps={basic}
+          layerCount={caps?.num_layers ?? 1}
+          morseCount={caps?.max_morse ?? 0}
+          {onpick}
+        />
       {:else if group === 'Basic' && !query}
         <KeyboardBasic
           extras={offBoard}

--- a/src/components/KeycodeSelect.svelte
+++ b/src/components/KeycodeSelect.svelte
@@ -1,6 +1,6 @@
 <script lang='ts'>
   import type { Snippet } from 'svelte'
-  import type { CatalogEntry } from '../lib/keycatalog'
+  import type { CatalogEntry, CatalogGroup } from '../lib/keycatalog'
   import type { DeviceCapabilities, KeyAction } from '../rynk'
   import Icon from '@iconify/svelte'
   import { RadioGroup } from 'bits-ui'
@@ -19,10 +19,10 @@
     /// Restricts the picker to plain HID keys, for callers like the macro
     /// editor whose wire format cannot hold anything richer.
     hidOnly?: boolean
-    /// Draws the key area on its own panel. The keymap editor needs it to lift
+    /// Draws the picker as its own panel. The keymap editor needs it to lift
     /// the keys off the ruled canvas; inside a dialog it would just box a box.
     panel?: boolean
-    /// Per-key controls the keymap editor hangs off the end of the rail.
+    /// Per-key controls the keymap editor hangs off the end of the header.
     rightSlot?: Snippet
   }
 
@@ -63,21 +63,34 @@
   })
   const tabs = $derived(hidOnly ? groups.map(g => g.name) : [...groups.map(g => g.name), HOLD_TAP])
   const basic = $derived(groups.find(g => g.name === 'Basic')?.entries ?? [])
-  const holdTap = $derived(group === HOLD_TAP && !query)
+
+  const needle = $derived(query.trim().toLowerCase())
+  /// Hold-Tap builds an action rather than listing one, so it keeps the header's
+  /// search box for its own tap keys and stays the current tab while typing.
+  const holdTap = $derived(group === HOLD_TAP)
+  const searching = $derived(needle !== '' && !holdTap)
 
   /// Basic's chip grid stands down while the board is drawn, but the entries the
   /// board has no place for still need somewhere to live.
   const offBoard = $derived(basic.filter(e => !e.hid || !BOARD_CODES.has(e.hid)))
 
-  const results = $derived.by<CatalogEntry[]>(() => {
-    const q = query.trim().toLowerCase()
-    if (q) {
-      return groups
-        .flatMap(g => g.entries)
-        .filter(e => e.label.toLowerCase().includes(q) || (e.title ?? '').toLowerCase().includes(q))
+  /// A search spans every group, so its hits stay grouped: a flat wall of chips
+  /// says nothing about whether a hit is a plain key, a layer op or a macro.
+  const shown = $derived.by<CatalogGroup[]>(() => {
+    if (!searching) {
+      const current = groups.find(g => g.name === group)
+      return current ? [current] : []
     }
-    return groups.find(g => g.name === group)?.entries ?? []
+    return groups
+      .map(g => ({ name: g.name, entries: g.entries.filter(e => matches(e, needle)) }))
+      .filter(g => g.entries.length > 0)
   })
+  const found = $derived(shown.reduce((n, g) => n + g.entries.length, 0))
+
+  function matches(entry: CatalogEntry, text: string): boolean {
+    return entry.label.toLowerCase().includes(text)
+      || (entry.title ?? '').toLowerCase().includes(text)
+  }
 
   function selectGroup(name: string) {
     group = name
@@ -89,27 +102,34 @@
   }
 </script>
 
-<div class='flex min-h-0 w-full flex-col overflow-hidden'>
+<!-- One surface: the categories sit inside the panel above a hairline, rather
+     than on a separate floating bar the keys hang off. -->
+<div
+  class={[
+    'flex min-h-0 w-full flex-col overflow-hidden',
+    panel && `rounded-[14px] border border-base-300 bg-base-100 shadow-bar`,
+  ]}
+>
   <div
-    class={`
-      relative z-10 flex flex-none items-center gap-1.5 rounded-[14px] border
-      border-base-300 bg-base-100 px-1.5 py-[5px] shadow-bar
-    `}
+    class={[
+      'flex flex-none items-center gap-2 border-b border-border',
+      panel ? 'px-3 py-2' : 'pb-2.5',
+    ]}
   >
-    <!-- While a search runs no group is current, so the bound value walks off
-         every radio rather than pinning the rail to a stale tab. -->
+    <!-- While a catalog search runs no group is current, so the bound value
+         walks off every radio rather than pinning a stale tab on. -->
     <RadioGroup.Root
       class='noscroll flex min-w-0 flex-1 gap-0.5 overflow-x-auto'
       orientation='horizontal'
-      bind:value={() => (query ? '' : group), selectGroup}
+      bind:value={() => (searching ? '' : group), selectGroup}
     >
       {#each tabs as name (name)}
-        {@const on = name === group && !query}
+        {@const on = name === group && !searching}
         <RadioGroup.Item
           class={[
             `
-              inline-flex h-[34px] flex-none cursor-pointer items-center gap-1.5
-              rounded-[10px] px-[13px] text-[13px] whitespace-nowrap
+              inline-flex h-8 flex-none cursor-pointer items-center gap-1.5
+              rounded-lg px-2.5 text-[12.5px] whitespace-nowrap
               transition-colors
             `,
             on
@@ -127,25 +147,40 @@
       {/each}
     </RadioGroup.Root>
 
-    {#if !holdTap}
-      <div class='relative flex-none basis-44'>
-        <Icon
-          class='absolute top-[9px] left-2.5 text-muted-foreground'
-          icon='lucide:search'
-          width={14}
-          height={14}
-        />
-        <input
+    <div class='relative flex-none basis-48'>
+      <Icon
+        class='absolute top-[9px] left-2.5 text-muted-foreground'
+        icon='lucide:search'
+        width={14}
+        height={14}
+      />
+      <input
+        class={`
+          h-8 w-full rounded-lg border border-input bg-background pr-7 pl-8
+          text-[12.5px] text-foreground transition-colors outline-none
+          focus:border-brand
+        `}
+        placeholder={holdTap ? 'Find tap key…' : 'Search keycodes…'}
+        aria-label={holdTap ? 'Search tap keys' : 'Search keycodes'}
+        bind:value={query}
+      />
+      {#if needle}
+        <button
           class={`
-            h-8 w-full rounded-md border border-input bg-background pr-2.5 pl-8
-            text-[13px] text-foreground outline-none
+            absolute top-1.5 right-1.5 inline-flex size-5 cursor-pointer
+            items-center justify-center rounded-md text-muted-foreground
+            transition-colors
+            hover:bg-base-200 hover:text-foreground
           `}
-          placeholder='Search…'
-          aria-label='Search keycodes'
-          bind:value={query}
-        />
-      </div>
-    {/if}
+          type='button'
+          aria-label='Clear search'
+          title='Clear search'
+          onclick={() => (query = '')}
+        >
+          <Icon icon='lucide:x' width={12} height={12} />
+        </button>
+      {/if}
+    </div>
 
     {#if rightSlot}
       <span class='h-[22px] w-px bg-border'></span>
@@ -153,58 +188,69 @@
     {/if}
   </div>
 
-  <!-- Hangs off the rail like an open menu: pulled up by the rail's corner
-       radius so its square top disappears behind it, leaving one surface. The
-       negative margin swallows 14px of the top padding, so `pt-8` leaves the
-       keys the same clearance under the rail that `pb-4` leaves below them. -->
   <div
     class={[
-      'flex min-h-0 flex-1 flex-col',
-      panel
-        ? `
-          mx-6 -mt-3.5 rounded-b-[14px] border border-t-0 border-base-300
-          bg-base-100 px-3 pt-7 pb-3 shadow-bar
-        `
-        : 'mt-2.5 px-2 pt-0.5 pb-1',
+      'noscroll min-h-0 flex-1 overflow-y-auto',
+      panel ? 'px-3 pt-2.5 pb-3' : 'pt-2.5',
     ]}
   >
-    <div class='noscroll min-h-0 flex-1 overflow-y-auto'>
-      {#if catalog.hid.length === 0}
-        <p class='p-2 text-[13px] text-muted-foreground'>Loading keycodes…</p>
-      {:else if holdTap}
-        <HoldTapBuilder
-          taps={basic}
-          layerCount={caps?.num_layers ?? 1}
-          morseCount={morseSlots}
-          {onpick}
-        />
-      {:else if group === 'Basic' && !query}
-        <KeyboardBasic
-          extras={offBoard}
-          onpick={pickHid}
-          onpickentry={entry => onpick(entry.action)}
-        />
-      {:else}
-        <div class='flex flex-wrap content-start gap-1'>
-          {#each results as entry (entry.id)}
-            <MiniKey
-              label={entry.label}
-              sub={entry.sub}
-              w={CHIP_UNITS}
-              tint={capLegend(entry.action).tint}
-              title={entry.title ?? entry.label}
-              action={entry.action}
-              onpick={() => onpick(entry.action)}
-            />
-          {/each}
-          {#if results.length === 0}
-            <span class='p-2 text-[13px] text-muted-foreground'>
-              No keycodes match “{query}”.
-            </span>
-          {/if}
-        </div>
-      {/if}
-    </div>
-
+    {#if catalog.hid.length === 0}
+      <p class='p-2 text-[13px] text-muted-foreground'>Loading keycodes…</p>
+    {:else if holdTap}
+      <HoldTapBuilder
+        taps={basic}
+        layerCount={caps?.num_layers ?? 1}
+        morseCount={morseSlots}
+        query={needle}
+        {onpick}
+      />
+    {:else if group === 'Basic' && !searching}
+      <KeyboardBasic
+        extras={offBoard}
+        onpick={pickHid}
+        onpickentry={entry => onpick(entry.action)}
+      />
+    {:else if found === 0}
+      <p class='p-2 text-[13px] text-muted-foreground'>
+        {searching ? `No keycodes match “${query.trim()}”.` : 'This group is empty.'}
+      </p>
+    {:else}
+      <div class='flex flex-col gap-3.5'>
+        {#each shown as section (section.name)}
+          <div class='flex flex-col gap-1.5'>
+            {#if searching}
+              <div class='flex items-center gap-1.5 text-muted-foreground'>
+                <Icon
+                  icon={GROUP_ICONS[section.name] ?? 'lucide:layout-grid'}
+                  width={12}
+                  height={12}
+                />
+                <span class='text-[10px] font-bold tracking-[0.06em] uppercase'>
+                  {section.name}
+                </span>
+                <span class='text-[10px] font-semibold opacity-70'>
+                  {section.entries.length}
+                </span>
+                <span class='h-px flex-1 bg-border'></span>
+              </div>
+            {/if}
+            <div class='flex flex-wrap content-start gap-1'>
+              {#each section.entries as entry (entry.id)}
+                <MiniKey
+                  label={entry.label}
+                  sub={entry.sub}
+                  w={CHIP_UNITS}
+                  tint={capLegend(entry.action).tint}
+                  title={entry.title ?? entry.label}
+                  action={entry.action}
+                  highlight={searching ? needle : undefined}
+                  onpick={() => onpick(entry.action)}
+                />
+              {/each}
+            </div>
+          </div>
+        {/each}
+      </div>
+    {/if}
   </div>
 </div>

--- a/src/components/KeycodeSelect.svelte
+++ b/src/components/KeycodeSelect.svelte
@@ -8,6 +8,7 @@
   import { actionCatalog } from '../lib/keycatalog'
   import { capLegend } from '../lib/legend'
   import { BOARD_CODES } from '../lib/picker-layout'
+  import { keyboardStore } from '../stores'
   import HoldTapBuilder from './HoldTapBuilder.svelte'
   import KeyboardBasic from './KeyboardBasic.svelte'
   import MiniKey from './MiniKey.svelte'
@@ -49,8 +50,12 @@
   let group = $state('Basic')
   let query = $state('')
 
+  /// The live table length, not `caps.max_morse`: that is only capacity, and
+  /// the firmware rejects a `Morse n` past the actual table.
+  const morseSlots = $derived(keyboardStore.config?.morses.length ?? 0)
+
   const groups = $derived.by(() => {
-    const all = actionCatalog(caps, catalog.hid)
+    const all = actionCatalog(caps, catalog.hid, morseSlots)
     if (!hidOnly) return all
     return all
       .map(g => ({ ...g, entries: g.entries.filter(e => e.hid !== undefined) }))
@@ -170,7 +175,7 @@
         <HoldTapBuilder
           taps={basic}
           layerCount={caps?.num_layers ?? 1}
-          morseCount={caps?.max_morse ?? 0}
+          morseCount={morseSlots}
           {onpick}
         />
       {:else if group === 'Basic' && !query}

--- a/src/components/LayerTabs.svelte
+++ b/src/components/LayerTabs.svelte
@@ -6,10 +6,14 @@
   interface Props {
     count: number
     layer: number
+    /// The layer the keyboard falls back to; marked with a star.
+    defaultLayer?: number
     onselect: (layer: number) => void
+    /// When set, the active tab offers "make this the default layer".
+    onsetdefault?: (layer: number) => void
   }
 
-  const { count, layer, onselect }: Props = $props()
+  const { count, layer, defaultLayer, onselect, onsetdefault }: Props = $props()
 </script>
 
 <div class='flex items-center gap-[5px]'>
@@ -44,9 +48,28 @@
       >
         <span class='size-2 rounded-full' style:background={layerColor(i)}></span>
         {i}
+        {#if i === defaultLayer}
+          <Icon icon='lucide:star' width={10} height={10} />
+        {/if}
       </RadioGroup.Item>
     {/each}
   </RadioGroup.Root>
+  {#if onsetdefault && defaultLayer !== undefined && layer !== defaultLayer}
+    <button
+      class={`
+        inline-flex h-6.5 flex-none cursor-pointer items-center gap-1
+        rounded-full border border-dashed border-border px-[9px] text-xs
+        font-bold text-muted-foreground
+        hover:border-brand hover:text-brand-darker
+      `}
+      type='button'
+      title='Make layer {layer} the default layer'
+      onclick={() => onsetdefault(layer)}
+    >
+      <Icon icon='lucide:star' width={11} height={11} />
+      Set default
+    </button>
+  {/if}
   <!-- The layer count is fixed at build time by the firmware's keyboard.toml. -->
   <button
     class={`

--- a/src/components/MiniKey.svelte
+++ b/src/components/MiniKey.svelte
@@ -16,8 +16,7 @@
     title?: string
     /// Set to make the key a drag source for the board.
     action?: KeyAction
-    /// Lowercased search text; the run of the label it matches is picked out, so
-    /// a hit found by title alone is visibly different from one on the legend.
+    /// Search text, already lowercased; the label run it matches is picked out.
     highlight?: string
     onpick: () => void
   }

--- a/src/components/MiniKey.svelte
+++ b/src/components/MiniKey.svelte
@@ -16,6 +16,9 @@
     title?: string
     /// Set to make the key a drag source for the board.
     action?: KeyAction
+    /// Lowercased search text; the run of the label it matches is picked out, so
+    /// a hit found by title alone is visibly different from one on the legend.
+    highlight?: string
     onpick: () => void
   }
 
@@ -27,8 +30,17 @@
     tint = 'base',
     title,
     action,
+    highlight,
     onpick,
   }: Props = $props()
+
+  const hit = $derived.by(() => {
+    if (!highlight) return null
+    const at = label.toLowerCase().indexOf(highlight)
+    if (at < 0) return null
+    const end = at + highlight.length
+    return { head: label.slice(0, at), mid: label.slice(at, end), tail: label.slice(end) }
+  })
 
   /// The picker is a control surface, not a board: only layer/macro and
   /// transport keys are tinted, so the colour still means something. Modifiers
@@ -71,7 +83,10 @@
   ondragend={() => drag.end()}
 >
   <span class={['text-center leading-[1.1] text-balance', SIZES[labelSize(label)]]}>
-    {label}
+    {#if hit}{hit.head}<span class='
+      text-brand-darker
+      dark:text-brand-fill
+    '>{hit.mid}</span>{hit.tail}{:else}{label}{/if}
   </span>
   {#if sub}
     <span class='text-[7px] leading-none opacity-55'>{sub}</span>

--- a/src/components/TopBar.svelte
+++ b/src/components/TopBar.svelte
@@ -45,17 +45,19 @@
 
   <span class='h-[26px] w-px flex-none bg-base-300'></span>
 
+  <!-- Safe centering: when the window is too narrow the row aligns to its
+       start and scrolls, instead of clipping both ends unreachably. -->
   <nav class='
-    noscroll flex min-w-0 flex-1 justify-center gap-0.5 overflow-x-auto
+    noscroll flex min-w-0 flex-1 justify-center-safe gap-0.5 overflow-x-auto
   '>
     {#each SCREENS as screen (screen.id)}
       {@const on = screens.current === screen.id}
       <button
         class={[
           `
-            inline-flex h-[38px] flex-none cursor-pointer items-center gap-1.5
-            rounded-[10px] px-[13px] text-[12.5px] whitespace-nowrap
-            transition-colors
+            inline-flex h-[46px] flex-none cursor-pointer flex-col items-center
+            justify-center gap-[3px] rounded-[10px] px-2 text-[10.5px]
+            whitespace-nowrap transition-colors
           `,
           on
             ? 'bg-brand-tint-strong font-bold text-brand-darker'
@@ -68,7 +70,7 @@
         title={screen.label}
         onclick={() => screens.go(screen.id)}
       >
-        <Icon icon={screen.icon} width={15} height={15} />
+        <Icon icon={screen.icon} width={16} height={16} />
         {screen.label}
       </button>
     {/each}

--- a/src/components/TopBar.svelte
+++ b/src/components/TopBar.svelte
@@ -2,8 +2,10 @@
   import type { TransportInfo } from '../rynk'
   import Icon from '@iconify/svelte'
   import { screens, SCREENS } from '../lib/screens.svelte'
-  import { deviceStore, keyboardStore } from '../stores'
+  import { toast } from '../lib/toast.svelte'
+  import { describeKeyboardError, deviceStore, keyboardStore } from '../stores'
   import LogoCard from './LogoCard.svelte'
+  import UnlockOverlay from './UnlockOverlay.svelte'
 
   /// How this app reached the keyboard. Deliberately not the keyboard's own
   /// output transport — that answers a different question and lives on the
@@ -17,6 +19,20 @@
 
   const connected = $derived(keyboardStore.connection?.phase === 'connected')
   const link = $derived(deviceStore.connectedKind ? LINKS[deviceStore.connectedKind] : null)
+
+  let unlocking = $state(false)
+
+  const lockStatus = $derived(keyboardStore.status?.lockStatus)
+  /// A device built without unlock_keys reports no challenge: unlocked ones
+  /// are insecure (lock() is a no-op), locked ones are permanently locked.
+  const lockable = $derived((lockStatus?.key_positions.length ?? 0) > 0)
+
+  function relock() {
+    void keyboardStore.lock().match(
+      () => toast.success('Keyboard locked'),
+      e => toast.error(describeKeyboardError(e)),
+    )
+  }
 </script>
 
 <div
@@ -63,6 +79,44 @@
   <!-- Edits are written to the keyboard as they are made, so this reports the
        link rather than offering a save. -->
   <div class='flex flex-none items-center gap-2.5 pr-1 pl-2'>
+    {#if lockStatus?.locked}
+      <button
+        class={[
+          `
+            inline-flex items-center gap-1 text-xs font-semibold
+            whitespace-nowrap text-brand-darker
+          `,
+          lockable
+            ? `
+              cursor-pointer
+              hover:brightness-90
+            `
+            : 'cursor-default',
+        ]}
+        type='button'
+        title={lockable
+          ? 'Security-sensitive commands are locked — click to unlock'
+          : 'This firmware has no unlock keys, so the lock is permanent'}
+        onclick={() => { if (lockable) unlocking = true }}
+      >
+        <Icon icon='lucide:lock' width={14} height={14} />
+        Locked
+      </button>
+    {:else if lockable}
+      <button
+        class={`
+          inline-flex cursor-pointer items-center gap-1 text-xs font-semibold
+          whitespace-nowrap text-muted-foreground
+          hover:text-foreground
+        `}
+        type='button'
+        title='Unlocked — click to lock security-sensitive commands again'
+        onclick={relock}
+      >
+        <Icon icon='lucide:lock-open' width={14} height={14} />
+        Unlocked
+      </button>
+    {/if}
     {#if link}
       <span
         class={[
@@ -106,3 +160,7 @@
     </button>
   </div>
 </div>
+
+{#if unlocking}
+  <UnlockOverlay onclose={() => (unlocking = false)} />
+{/if}

--- a/src/components/UnlockOverlay.svelte
+++ b/src/components/UnlockOverlay.svelte
@@ -1,0 +1,96 @@
+<script lang='ts'>
+  import Icon from '@iconify/svelte'
+  import { capLegend } from '../lib/legend'
+  import { toast } from '../lib/toast.svelte'
+  import { keyboardStore } from '../stores'
+  import Overlay from './ui/Overlay.svelte'
+
+  interface Props {
+    onclose: () => void
+  }
+
+  const { onclose }: Props = $props()
+
+  /// The firmware samples the held challenge on each poll and lapses ~500ms
+  /// after polls stop, so cancelling is simply closing this overlay.
+  const POLL_MS = 150
+
+  const status = $derived(keyboardStore.status?.lockStatus)
+  const positions = $derived(status?.key_positions ?? [])
+  const held = $derived(positions.length - (status?.remaining_keys ?? positions.length))
+
+  function keyLabel(row: number, col: number): string {
+    const action = keyboardStore.config?.keymap[0]?.[row]?.[col]
+    if (!action) return `R${row}C${col}`
+    const legend = capLegend(action, keyboardStore.device?.capabilities).main
+    // The base layer can hold a glyph with no name at this position.
+    return legend === '✕' || legend === '▽' ? `R${row}C${col}` : legend
+  }
+
+  $effect(() => {
+    let cancelled = false
+    let timer: ReturnType<typeof setTimeout>
+    // Self-scheduling rather than an interval: a poll is a queued client call,
+    // and a slow link must not pile up a burst of them.
+    const poll = () => {
+      void keyboardStore.unlockPoll().match(
+        (s) => {
+          if (cancelled) return
+          if (!s.locked) {
+            toast.success('Keyboard unlocked')
+            onclose()
+            return
+          }
+          timer = setTimeout(poll, POLL_MS)
+        },
+        () => { if (!cancelled) timer = setTimeout(poll, POLL_MS * 4) },
+      )
+    }
+    poll()
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+    }
+  })
+</script>
+
+<Overlay
+  title='Unlock keyboard'
+  subtitle='A physical-presence check guards security-sensitive commands.'
+  {onclose}
+>
+  <div class='flex flex-1 flex-col items-center justify-center gap-5'>
+    <p class='max-w-105 text-center text-[13px] text-muted-foreground'>
+      Press and hold
+      {positions.length === 1 ? 'this key' : `all ${positions.length} keys at once`}
+      on the keyboard until it unlocks.
+    </p>
+
+    <div class='flex flex-wrap items-center justify-center gap-2'>
+      {#each positions as [row, col], i ([row, col].join())}
+        {#if i > 0}
+          <Icon class='text-muted-foreground' icon='lucide:plus' width={14} height={14} />
+        {/if}
+        <span
+          class={`
+            inline-flex h-12 min-w-12 items-center justify-center rounded-lg
+            border-2 border-brand bg-brand-tint px-3 text-[15px] font-bold
+            text-brand-darker
+          `}
+        >
+          {keyLabel(row, col)}
+        </span>
+      {/each}
+    </div>
+
+    <div class='flex items-center gap-2 text-[13px] font-semibold'>
+      {#if status?.unlocking}
+        <span class='size-2 animate-pulse rounded-full bg-brand'></span>
+        <span class='text-foreground'>{held} of {positions.length} keys held…</span>
+      {:else}
+        <span class='size-2 rounded-full bg-muted-foreground'></span>
+        <span class='text-muted-foreground'>Waiting for the keyboard…</span>
+      {/if}
+    </div>
+  </div>
+</Overlay>

--- a/src/components/Workspace.svelte
+++ b/src/components/Workspace.svelte
@@ -3,9 +3,12 @@
   import Behavior from '../pages/Behavior.svelte'
   import Combos from '../pages/Combos.svelte'
   import Device from '../pages/Device.svelte'
+  import Forks from '../pages/Forks.svelte'
   import Keymap from '../pages/Keymap.svelte'
   import Macros from '../pages/Macros.svelte'
+  import Morses from '../pages/Morses.svelte'
   import Settings from '../pages/Settings.svelte'
+  import Tester from '../pages/Tester.svelte'
   import TopBar from './TopBar.svelte'
 
   /// Which layer the keymap editor is showing.
@@ -23,6 +26,12 @@
     <Macros />
   {:else if screens.current === 'combos'}
     <Combos />
+  {:else if screens.current === 'morse'}
+    <Morses />
+  {:else if screens.current === 'forks'}
+    <Forks />
+  {:else if screens.current === 'tester'}
+    <Tester />
   {:else if screens.current === 'device'}
     <Device />
   {:else if screens.current === 'behavior'}

--- a/src/components/ui/ConfirmOverlay.svelte
+++ b/src/components/ui/ConfirmOverlay.svelte
@@ -1,0 +1,35 @@
+<script lang='ts'>
+  import type { Snippet } from 'svelte'
+  import Button from './Button.svelte'
+  import Overlay from './Overlay.svelte'
+
+  interface Props {
+    title: string
+    confirmLabel: string
+    onconfirm: () => void
+    onclose: () => void
+    children: Snippet
+  }
+
+  const { title, confirmLabel, onconfirm, onclose, children }: Props = $props()
+</script>
+
+<Overlay {title} {onclose} slim>
+  <div class='flex flex-1 flex-col gap-4'>
+    <div class='text-[13px] leading-relaxed text-muted-foreground'>
+      {@render children()}
+    </div>
+    <div class='mt-auto flex justify-end gap-2'>
+      <Button onclick={onclose}>Cancel</Button>
+      <Button
+        variant='brand'
+        onclick={() => {
+          onconfirm()
+          onclose()
+        }}
+      >
+        {confirmLabel}
+      </Button>
+    </div>
+  </div>
+</Overlay>

--- a/src/components/ui/Overlay.svelte
+++ b/src/components/ui/Overlay.svelte
@@ -6,11 +6,13 @@
   interface Props {
     title: string
     subtitle?: string
+    /// Compact dialog for confirmations; the default fits the keycode picker.
+    slim?: boolean
     onclose: () => void
     children: Snippet
   }
 
-  const { title, subtitle, onclose, children }: Props = $props()
+  const { title, subtitle, slim = false, onclose, children }: Props = $props()
 </script>
 
 <!-- The parent mounts this only while open, so the dialog is always open and
@@ -25,11 +27,16 @@
       `}
     />
     <Dialog.Content
-      class={`
-        fixed top-1/2 left-1/2 z-90 flex h-[min(560px,86%)] w-[min(900px,92%)]
-        -translate-1/2 flex-col overflow-hidden rounded-lg border border-border
-        bg-background shadow-lg
-      `}
+      class={[
+        `
+          fixed top-1/2 left-1/2 z-90 flex -translate-1/2 flex-col
+          overflow-hidden rounded-lg border border-border bg-background
+          shadow-lg
+        `,
+        slim
+          ? 'max-h-[86%] w-[min(440px,92%)]'
+          : 'h-[min(560px,86%)] w-[min(900px,92%)]',
+      ]}
     >
       <div class='
         flex items-center gap-3 border-b border-border px-[18px] py-3.5

--- a/src/lib/icons.json
+++ b/src/lib/icons.json
@@ -1,6 +1,9 @@
 {
   "prefix": "lucide",
   "icons": {
+    "activity": {
+      "body": "<path fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.25.25 0 0 1-.48 0L9.24 2.18a.25.25 0 0 0-.48 0l-2.35 8.36A2 2 0 0 1 4.49 12H2\"/>"
+    },
     "battery": {
       "body": "<g fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\"><path d=\"M22 14v-4\"/><rect width=\"16\" height=\"12\" x=\"2\" y=\"6\" rx=\"2\"/></g>"
     },
@@ -34,8 +37,17 @@
     "cpu": {
       "body": "<g fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\"><path d=\"M12 20v2m0-20v2m5 16v2m0-20v2M2 12h2m-2 5h2M2 7h2m16 5h2m-2 5h2M20 7h2M7 20v2M7 2v2\"/><rect width=\"16\" height=\"16\" x=\"4\" y=\"4\" rx=\"2\"/><rect width=\"8\" height=\"8\" x=\"8\" y=\"8\" rx=\"1\"/></g>"
     },
+    "delete": {
+      "body": "<path fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M10 5a2 2 0 0 0-1.344.519l-6.328 5.74a1 1 0 0 0 0 1.481l6.328 5.741A2 2 0 0 0 10 19h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2zm2 4l6 6m0-6l-6 6\"/>"
+    },
+    "ellipsis": {
+      "body": "<g fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\"><circle cx=\"12\" cy=\"12\" r=\"1\"/><circle cx=\"19\" cy=\"12\" r=\"1\"/><circle cx=\"5\" cy=\"12\" r=\"1\"/></g>"
+    },
     "eraser": {
       "body": "<path fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M21 21H8a2 2 0 0 1-1.42-.587l-3.994-3.999a2 2 0 0 1 0-2.828l10-10a2 2 0 0 1 2.829 0l5.999 6a2 2 0 0 1 0 2.828L12.834 21m-7.752-9.91l8.828 8.828\"/>"
+    },
+    "folder-open": {
+      "body": "<path fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"m6 14l1.5-2.9A2 2 0 0 1 9.24 10H20a2 2 0 0 1 1.94 2.5l-1.54 6a2 2 0 0 1-1.95 1.5H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h3.9a2 2 0 0 1 1.69.9l.81 1.2a2 2 0 0 0 1.67.9H18a2 2 0 0 1 2 2v2\"/>"
     },
     "info": {
       "body": "<g fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\"><circle cx=\"12\" cy=\"12\" r=\"10\"/><path d=\"M12 16v-4m0-4h.01\"/></g>"
@@ -51,6 +63,12 @@
     },
     "lightbulb": {
       "body": "<path fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M15 14c.2-1 .7-1.7 1.5-2.5c1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5c.7.7 1.3 1.5 1.5 2.5m0 4h6m-5 4h4\"/>"
+    },
+    "lock": {
+      "body": "<g fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\"><rect width=\"18\" height=\"11\" x=\"3\" y=\"11\" rx=\"2\" ry=\"2\"/><path d=\"M7 11V7a5 5 0 0 1 10 0v4\"/></g>"
+    },
+    "lock-open": {
+      "body": "<g fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\"><rect width=\"18\" height=\"11\" x=\"3\" y=\"11\" rx=\"2\" ry=\"2\"/><path d=\"M7 11V7a5 5 0 0 1 9.9-1\"/></g>"
     },
     "moon": {
       "body": "<path fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M20.985 12.486a9 9 0 1 1-9.473-9.472c.405-.022.617.46.402.803a6 6 0 0 0 8.268 8.268c.344-.215.825-.004.803.401\"/>"
@@ -73,6 +91,12 @@
     "refresh-cw": {
       "body": "<g fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\"><path d=\"M3 12a9 9 0 0 1 9-9a9.75 9.75 0 0 1 6.74 2.74L21 8\"/><path d=\"M21 3v5h-5m5 4a9 9 0 0 1-9 9a9.75 9.75 0 0 1-6.74-2.74L3 16\"/><path d=\"M8 16H3v5\"/></g>"
     },
+    "rotate-ccw": {
+      "body": "<g fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\"><path d=\"M3 12a9 9 0 1 0 9-9a9.75 9.75 0 0 0-6.74 2.74L3 8\"/><path d=\"M3 3v5h5\"/></g>"
+    },
+    "rotate-cw": {
+      "body": "<g fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\"><path d=\"M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8\"/><path d=\"M21 3v5h-5\"/></g>"
+    },
     "save": {
       "body": "<g fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\"><path d=\"M15.2 3a2 2 0 0 1 1.4.6l3.8 3.8a2 2 0 0 1 .6 1.4V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z\"/><path d=\"M17 21v-7a1 1 0 0 0-1-1H8a1 1 0 0 0-1 1v7M7 3v4a1 1 0 0 0 1 1h7\"/></g>"
     },
@@ -82,17 +106,29 @@
     "settings": {
       "body": "<g fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\"><path d=\"M9.671 4.136a2.34 2.34 0 0 1 4.659 0a2.34 2.34 0 0 0 3.319 1.915a2.34 2.34 0 0 1 2.33 4.033a2.34 2.34 0 0 0 0 3.831a2.34 2.34 0 0 1-2.33 4.033a2.34 2.34 0 0 0-3.319 1.915a2.34 2.34 0 0 1-4.659 0a2.34 2.34 0 0 0-3.32-1.915a2.34 2.34 0 0 1-2.33-4.033a2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915\"/><circle cx=\"12\" cy=\"12\" r=\"3\"/></g>"
     },
+    "settings-2": {
+      "body": "<g fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\"><path d=\"M14 17H5M19 7h-9\"/><circle cx=\"17\" cy=\"17\" r=\"3\"/><circle cx=\"7\" cy=\"7\" r=\"3\"/></g>"
+    },
     "sliders-vertical": {
       "body": "<path fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M10 8h4m-2 13v-9m0-4V3m5 13h4m-2-4V3m0 18v-5M3 14h4m-2-4V3m0 18v-7\"/>"
     },
     "sparkles": {
       "body": "<g fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\"><path d=\"M11.017 2.814a1 1 0 0 1 1.966 0l1.051 5.558a2 2 0 0 0 1.594 1.594l5.558 1.051a1 1 0 0 1 0 1.966l-5.558 1.051a2 2 0 0 0-1.594 1.594l-1.051 5.558a1 1 0 0 1-1.966 0l-1.051-5.558a2 2 0 0 0-1.594-1.594l-5.558-1.051a1 1 0 0 1 0-1.966l5.558-1.051a2 2 0 0 0 1.594-1.594zM20 2v4m2-2h-4\"/><circle cx=\"4\" cy=\"20\" r=\"2\"/></g>"
     },
+    "split": {
+      "body": "<g fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\"><path d=\"M16 3h5v5M8 3H3v5\"/><path d=\"M12 22v-8.3a4 4 0 0 0-1.172-2.872L3 3m12 6l6-6\"/></g>"
+    },
+    "star": {
+      "body": "<path fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M11.525 2.295a.53.53 0 0 1 .95 0l2.31 4.679a2.12 2.12 0 0 0 1.595 1.16l5.166.756a.53.53 0 0 1 .294.904l-3.736 3.638a2.12 2.12 0 0 0-.611 1.878l.882 5.14a.53.53 0 0 1-.771.56l-4.618-2.428a2.12 2.12 0 0 0-1.973 0L6.396 21.01a.53.53 0 0 1-.77-.56l.881-5.139a2.12 2.12 0 0 0-.611-1.879L2.16 9.795a.53.53 0 0 1 .294-.906l5.165-.755a2.12 2.12 0 0 0 1.597-1.16z\"/>"
+    },
     "sun": {
       "body": "<g fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\"><circle cx=\"12\" cy=\"12\" r=\"4\"/><path d=\"M12 2v2m0 16v2M4.93 4.93l1.41 1.41m11.32 11.32l1.41 1.41M2 12h2m16 0h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41\"/></g>"
     },
     "target": {
       "body": "<g fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\"><circle cx=\"12\" cy=\"12\" r=\"10\"/><circle cx=\"12\" cy=\"12\" r=\"6\"/><circle cx=\"12\" cy=\"12\" r=\"2\"/></g>"
+    },
+    "timer": {
+      "body": "<g fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\"><path d=\"M10 2h4m-2 12l3-3\"/><circle cx=\"12\" cy=\"14\" r=\"8\"/></g>"
     },
     "trash-2": {
       "body": "<path fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M10 11v6m4-6v6m5-11v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2\"/>"

--- a/src/lib/keycatalog.test.ts
+++ b/src/lib/keycatalog.test.ts
@@ -46,10 +46,18 @@ describe('actionCatalog', () => {
     const bare = actionCatalog({ ...CAPS, max_morse: 0, macro_space_size: 0, lighting_enabled: false }, HID)
     expect(bare.map(g => g.name)).not.toContain('Light')
     const advanced = bare.find(g => g.name === 'Advanced')!.entries.map(e => e.id)
-    expect(advanced.some(id => id.startsWith('morse'))).toBe(false)
+    expect(advanced.some(id => id.startsWith('Morse'))).toBe(false)
     expect(advanced.some(id => id.startsWith('Macro'))).toBe(false)
     // The one-shots and special behaviours need no capability.
     expect(advanced).toContain('OSM LCtrl')
+  })
+
+  it('offers one Morse reference per live slot, not per capacity slot', () => {
+    // max_morse is 4, but the fixture's live table holds 2 — a Morse 2 would
+    // be rejected by the firmware, so it must not be offered.
+    const advanced = actionCatalog(CAPS, HID, 2).find(g => g.name === 'Advanced')!
+    const morses = advanced.entries.filter(e => e.id.startsWith('Morse'))
+    expect(morses.map(e => e.action)).toEqual([{ Morse: 0 }, { Morse: 1 }])
   })
 
   it('offers one layer action per layer', () => {

--- a/src/lib/keycatalog.ts
+++ b/src/lib/keycatalog.ts
@@ -151,6 +151,14 @@ export function actionCatalog(
           { length: (caps?.macro_space_size ?? 0) > 0 ? MACRO_SLOTS : 0 },
           (_, i) => act(`Macro ${i}`, { TriggerMacro: i }),
         ),
+        // Morse is the one KeyAction that is not `Single`-wrapped: the slot
+        // reference is the whole action.
+        ...Array.from({ length: caps?.max_morse ?? 0 }, (_, i): CatalogEntry => ({
+          id: `Morse ${i}`,
+          label: `Morse ${i}`,
+          action: { Morse: i },
+          title: `Morse key ${i} — tap/hold patterns from the Morse screen`,
+        })),
       ],
     },
   ]

--- a/src/lib/keycatalog.ts
+++ b/src/lib/keycatalog.ts
@@ -84,6 +84,9 @@ const NOT_BINDABLE: readonly HidKeyCode[] = ['No', 'ErrorRollover', 'PostFail', 
 export function actionCatalog(
   caps: DeviceCapabilities | undefined,
   hid: readonly HidKeyCode[] = [],
+  /// Live morse-table length — `caps.max_morse` is only the build-time
+  /// capacity, and the firmware rejects references past the actual table.
+  morseSlots = 0,
 ): CatalogGroup[] {
   // Every group is a view over the firmware's table, so without it there is
   // nothing honest to offer — the picker waits the one tick it takes to arrive.
@@ -153,7 +156,7 @@ export function actionCatalog(
         ),
         // Morse is the one KeyAction that is not `Single`-wrapped: the slot
         // reference is the whole action.
-        ...Array.from({ length: caps?.max_morse ?? 0 }, (_, i): CatalogEntry => ({
+        ...Array.from({ length: morseSlots }, (_, i): CatalogEntry => ({
           id: `Morse ${i}`,
           label: `Morse ${i}`,
           action: { Morse: i },

--- a/src/lib/matrix.test.ts
+++ b/src/lib/matrix.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { pressedCells } from './matrix'
+
+describe('pressedCells', () => {
+  it('decodes bit 0 as column 0, row-major', () => {
+    // 2 rows × 10 cols → 2 bytes per row.
+    const state = { pressed_bitmap: [0b0000_0101, 0b0000_0010, 0b0000_0000, 0b0000_0001] }
+    expect(pressedCells(state, 2, 10)).toEqual(new Set(['0,0', '0,2', '0,9', '1,8']))
+  })
+
+  it('treats a short bitmap as nothing pressed', () => {
+    expect(pressedCells({ pressed_bitmap: [] }, 2, 10)).toEqual(new Set())
+  })
+})

--- a/src/lib/matrix.ts
+++ b/src/lib/matrix.ts
@@ -1,0 +1,16 @@
+import type { MatrixState } from '../rynk'
+
+/// The matrix bitmap is row-major: each row occupies `ceil(cols / 8)` bytes,
+/// bit 0 of a row's first byte is column 0. Decoded to `"row,col"` keys, the
+/// same cell format the board keys its keycaps by.
+export function pressedCells(state: MatrixState, rows: number, cols: number): Set<string> {
+  const bytesPerRow = Math.ceil(cols / 8)
+  const pressed = new Set<string>()
+  for (let row = 0; row < rows; row++) {
+    for (let col = 0; col < cols; col++) {
+      const byte = state.pressed_bitmap[row * bytesPerRow + (col >> 3)] ?? 0
+      if (byte & (1 << (col & 7))) pressed.add(`${row},${col}`)
+    }
+  }
+  return pressed
+}

--- a/src/lib/morse.test.ts
+++ b/src/lib/morse.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { decodePattern, DOUBLE_TAP, encodePattern, HOLD, HOLD_AFTER_TAP, patternName, TAP } from './morse'
+
+describe('morse pattern codec', () => {
+  // The wire constants are the protocol's own encodings (rmk-types morse.rs).
+  it('decodes the named wire encodings', () => {
+    expect(decodePattern(TAP)).toEqual(['tap'])
+    expect(decodePattern(HOLD)).toEqual(['hold'])
+    expect(decodePattern(DOUBLE_TAP)).toEqual(['tap', 'tap'])
+    expect(decodePattern(HOLD_AFTER_TAP)).toEqual(['tap', 'hold'])
+  })
+
+  it('decodes empty', () => {
+    expect(decodePattern(0b1)).toEqual([])
+  })
+
+  it('encodes back to the same wire value', () => {
+    for (const pattern of [0b1, TAP, HOLD, DOUBLE_TAP, HOLD_AFTER_TAP, 0b110101, 0b1111111111111111]) {
+      expect(encodePattern(decodePattern(pattern))).toBe(pattern)
+    }
+  })
+
+  it('keeps step order: first step is emitted first', () => {
+    // tap-then-hold is 0b101: marker, then 0 (tap), then 1 (hold).
+    expect(encodePattern(['tap', 'hold'])).toBe(0b101)
+    expect(encodePattern(['hold', 'tap'])).toBe(0b110)
+  })
+
+  it('names the common patterns, spells out the rest', () => {
+    expect(patternName(TAP)).toBe('Tap')
+    expect(patternName(HOLD_AFTER_TAP)).toBe('Tap, hold')
+    expect(patternName(0b110)).toBe('hold, tap')
+  })
+})

--- a/src/lib/morse.ts
+++ b/src/lib/morse.ts
@@ -1,0 +1,41 @@
+/// A morse pattern is a tap/hold sequence packed into a u16: `0b1` is empty,
+/// and each step shifts left and sets the low bit for hold. The high set bit
+/// is a marker, not a step, so the first step is the bit just below it.
+
+export type MorseStep = 'tap' | 'hold'
+
+/// The wire's named encodings, used as picker presets.
+export const TAP = 0b10
+export const HOLD = 0b11
+export const DOUBLE_TAP = 0b100
+export const HOLD_AFTER_TAP = 0b101
+
+export const MAX_PATTERN_STEPS = 15
+
+export function decodePattern(pattern: number): MorseStep[] {
+  const marker = 31 - Math.clz32(pattern)
+  const steps: MorseStep[] = []
+  for (let i = marker - 1; i >= 0; i--) {
+    steps.push((pattern >> i) & 1 ? 'hold' : 'tap')
+  }
+  return steps
+}
+
+export function encodePattern(steps: MorseStep[]): number {
+  let pattern = 0b1
+  for (const step of steps) pattern = (pattern << 1) | (step === 'hold' ? 1 : 0)
+  return pattern
+}
+
+const NAMED: Record<number, string> = {
+  [TAP]: 'Tap',
+  [HOLD]: 'Hold',
+  [DOUBLE_TAP]: 'Double tap',
+  [HOLD_AFTER_TAP]: 'Tap, hold',
+}
+
+export function patternName(pattern: number): string {
+  const named = NAMED[pattern]
+  if (named) return named
+  return decodePattern(pattern).join(', ')
+}

--- a/src/lib/screens.svelte.ts
+++ b/src/lib/screens.svelte.ts
@@ -1,9 +1,14 @@
-export type ScreenId = 'keymap' | 'macros' | 'combos' | 'device' | 'behavior' | 'settings'
+export type ScreenId
+  = | 'keymap' | 'macros' | 'combos' | 'morse' | 'forks' | 'tester'
+    | 'device' | 'behavior' | 'settings'
 
 export const SCREENS = [
   { id: 'keymap', icon: 'lucide:keyboard', label: 'Keymap' },
   { id: 'macros', icon: 'lucide:zap', label: 'Macros' },
   { id: 'combos', icon: 'lucide:combine', label: 'Combos' },
+  { id: 'morse', icon: 'lucide:ellipsis', label: 'Morse' },
+  { id: 'forks', icon: 'lucide:split', label: 'Overrides' },
+  { id: 'tester', icon: 'lucide:activity', label: 'Test' },
   { id: 'device', icon: 'lucide:cpu', label: 'Device' },
   { id: 'behavior', icon: 'lucide:sliders-vertical', label: 'Behavior' },
   { id: 'settings', icon: 'lucide:settings', label: 'Settings' },

--- a/src/pages/Connect.svelte
+++ b/src/pages/Connect.svelte
@@ -181,30 +181,43 @@
               </button>
             {/each}
 
-            {#if deviceStore.scanning && list.length === 0}
-              <p
-                class={`
-                  flex flex-1 items-center justify-center gap-2.5 px-2 py-3
-                  text-center text-[13px] text-muted-foreground
-                `}
-              >
-                <span
-                  class={`
-                    inline-block size-[15px] flex-none animate-spin rounded-full
-                    border-2 border-muted border-t-brand
-                  `}
-                ></span>
-                Looking for {m.label} keyboards…
-              </p>
-            {:else if list.length === 0}
-              <p
-                class={`
-                  flex flex-1 items-center justify-center px-2 py-3 text-center
-                  text-[13px] text-muted-foreground
-                `}
-              >
-                <span>No {m.label} keyboards yet. {HINTS[m.value]}</span>
-              </p>
+            {#if list.length === 0}
+              <!-- Spinner and hint stack like the lists above, the idle one
+                   invisible: they trade places on every scan, and when the
+                   multi-line hint is what holds the card open, letting it
+                   unmount would bounce the whole column for the scan's
+                   duration. -->
+              <div class='grid flex-1'>
+                <p
+                  class={[
+                    `
+                      col-start-1 row-start-1 flex items-center justify-center
+                      gap-2.5 px-2 py-3 text-center text-[13px]
+                      text-muted-foreground
+                    `,
+                    !deviceStore.scanning && 'invisible',
+                  ]}
+                >
+                  <span
+                    class={`
+                      inline-block size-[15px] flex-none animate-spin
+                      rounded-full border-2 border-muted border-t-brand
+                    `}
+                  ></span>
+                  Looking for {m.label} keyboards…
+                </p>
+                <p
+                  class={[
+                    `
+                      col-start-1 row-start-1 flex items-center justify-center
+                      px-2 py-3 text-center text-[13px] text-muted-foreground
+                    `,
+                    deviceStore.scanning && 'invisible',
+                  ]}
+                >
+                  <span>No {m.label} keyboards yet. {HINTS[m.value]}</span>
+                </p>
+              </div>
             {/if}
           </div>
         {/each}

--- a/src/pages/Connect.svelte
+++ b/src/pages/Connect.svelte
@@ -52,7 +52,9 @@
     usb: 'Plug the keyboard in over USB.',
     ble: native
       ? 'Turn the keyboard on and bring it in range.'
-      : 'Pair the keyboard with this computer first — the browser can only reach a keyboard the system has already bonded.',
+      // The WebHID picker behind this tab is also the only browser route to a
+      // Vial keyboard, USB ones included — say so or nobody finds it.
+      : 'Pair the keyboard with this computer first — the browser can only reach a keyboard the system has already bonded. Vial keyboards, USB ones too, are picked from this tab.',
   }
   const available = $derived(deviceStore.browserTransports)
   const canPick = $derived(!native && available.includes(PICKS[method]))

--- a/src/pages/Device.svelte
+++ b/src/pages/Device.svelte
@@ -16,6 +16,7 @@
   const device = $derived(keyboardStore.device)
   const status = $derived(keyboardStore.status)
   const caps = $derived(device?.capabilities)
+  const vial = $derived(device?.protocol === 'vial')
   const cells = $derived(batteryCells(status))
   const output = $derived(outputLabel(activeOutput(status)))
   const connected = $derived(keyboardStore.connection?.phase === 'connected')
@@ -88,6 +89,9 @@
             {formFactor(device)}{device?.info.manufacturer ? ` · ${device.info.manufacturer}` : ''}
           </div>
         </div>
+        {#if vial}
+          <Pill tone='blue'>Vial</Pill>
+        {/if}
         {#if connected}
           <Pill tone='ok' dot>Connected</Pill>
         {:else}
@@ -171,10 +175,18 @@
         <Icon icon='lucide:cpu' width={24} height={24} />
       </div>
       <div class='flex-1'>
-        <div class='text-[15px] font-semibold text-foreground'>RMK firmware</div>
+        <div class='text-[15px] font-semibold text-foreground'>
+          {vial ? 'Firmware' : 'RMK firmware'}
+        </div>
         <div class='text-xs text-muted-foreground'>
-          Installed {firmwareVersion(device)} · Rynk protocol
-          {device?.version.major}.{device?.version.minor}
+          <!-- Vial carries no firmware version on the wire, so only the
+               protocol generation is real. -->
+          {#if vial}
+            Vial protocol {device?.version.minor}
+          {:else}
+            Installed {firmwareVersion(device)} · Rynk protocol
+            {device?.version.major}.{device?.version.minor}
+          {/if}
         </div>
       </div>
       <!-- There is no firmware-transfer endpoint in the protocol. -->
@@ -193,15 +205,20 @@
       <Button class='ml-auto' onclick={bootloader}>Enter bootloader</Button>
     </div>
 
-    <div class='mt-3.5 flex items-center gap-3.5 border-t border-border pt-3.5'>
-      <div>
-        <div class='text-[13.5px] font-semibold text-foreground'>Restart keyboard</div>
-        <div class='text-xs text-muted-foreground'>
-          Reboot the firmware. This ends the session.
+    <!-- Vial has no reboot command; only DFU entry. -->
+    {#if !vial}
+      <div class='
+        mt-3.5 flex items-center gap-3.5 border-t border-border pt-3.5
+      '>
+        <div>
+          <div class='text-[13.5px] font-semibold text-foreground'>Restart keyboard</div>
+          <div class='text-xs text-muted-foreground'>
+            Reboot the firmware. This ends the session.
+          </div>
         </div>
+        <Button class='ml-auto' onclick={reboot}>Restart</Button>
       </div>
-      <Button class='ml-auto' onclick={reboot}>Restart</Button>
-    </div>
+    {/if}
 
     {#if caps?.storage_enabled}
       <div class='

--- a/src/pages/Device.svelte
+++ b/src/pages/Device.svelte
@@ -2,6 +2,7 @@
   import Icon from '@iconify/svelte'
   import Button from '../components/ui/Button.svelte'
   import Card from '../components/ui/Card.svelte'
+  import ConfirmOverlay from '../components/ui/ConfirmOverlay.svelte'
   import Pill from '../components/ui/Pill.svelte'
   import Row from '../components/ui/Row.svelte'
   import ScreenScroll from '../components/ui/ScreenScroll.svelte'
@@ -25,10 +26,26 @@
   /// without it would otherwise gain a row that can never become active.
   const onDongle = $derived(activeProfile === dongleSlot(caps))
 
+  let confirming = $state<'reset' | null>(null)
+
   function bootloader() {
     void keyboardStore.bootloaderJump().match(
       // Not `success`: the jump ends the session, it does not complete a change.
       () => toast.info('Rebooting into bootloader…'),
+      e => toast.error(describeKeyboardError(e)),
+    )
+  }
+
+  function reboot() {
+    void keyboardStore.reboot().match(
+      () => toast.info('Rebooting…'),
+      e => toast.error(describeKeyboardError(e)),
+    )
+  }
+
+  function resetStorage() {
+    void keyboardStore.storageReset('Full').match(
+      () => toast.success('Storage reset — the keyboard is back to its built-in defaults'),
       e => toast.error(describeKeyboardError(e)),
     )
   }
@@ -175,6 +192,34 @@
       </div>
       <Button class='ml-auto' onclick={bootloader}>Enter bootloader</Button>
     </div>
+
+    <div class='mt-3.5 flex items-center gap-3.5 border-t border-border pt-3.5'>
+      <div>
+        <div class='text-[13.5px] font-semibold text-foreground'>Restart keyboard</div>
+        <div class='text-xs text-muted-foreground'>
+          Reboot the firmware. This ends the session.
+        </div>
+      </div>
+      <Button class='ml-auto' onclick={reboot}>Restart</Button>
+    </div>
+
+    {#if caps?.storage_enabled}
+      <div class='
+        mt-3.5 flex items-center gap-3.5 border-t border-border pt-3.5
+      '>
+        <div>
+          <div class='text-[13.5px] font-semibold text-foreground'>Reset stored settings</div>
+          <div class='text-xs text-muted-foreground'>
+            Wipe the keymap, macros, and every other stored setting — including
+            Bluetooth bonds.
+          </div>
+        </div>
+        <Button class='ml-auto' onclick={() => (confirming = 'reset')}>
+          <Icon icon='lucide:trash-2' width={14} height={14} />
+          Reset
+        </Button>
+      </div>
+    {/if}
   </Card>
 
   <Card flush>
@@ -256,3 +301,16 @@
     {/if}
   </Card>
 </ScreenScroll>
+
+{#if confirming === 'reset'}
+  <ConfirmOverlay
+    title='Reset stored settings?'
+    confirmLabel='Reset everything'
+    onconfirm={resetStorage}
+    onclose={() => (confirming = null)}
+  >
+    Every setting stored on the keyboard is wiped: keymap, combos, macros,
+    morse keys, and Bluetooth bonds. The keyboard falls back to the defaults
+    built into its firmware. This cannot be undone.
+  </ConfirmOverlay>
+{/if}

--- a/src/pages/Forks.svelte
+++ b/src/pages/Forks.svelte
@@ -1,0 +1,302 @@
+<script lang='ts'>
+  import type { Fork, KeyAction, LedIndicator, ModifierCombination, MouseButtons, StateBits } from '../rynk'
+  import Icon from '@iconify/svelte'
+  import KeycodeSelect from '../components/KeycodeSelect.svelte'
+  import Button from '../components/ui/Button.svelte'
+  import Card from '../components/ui/Card.svelte'
+  import IconBtn from '../components/ui/IconBtn.svelte'
+  import Overlay from '../components/ui/Overlay.svelte'
+  import ScreenScroll from '../components/ui/ScreenScroll.svelte'
+  import { keyActionText, NO_MODIFIERS } from '../lib/keycode'
+  import { capLegend } from '../lib/legend'
+  import { toast } from '../lib/toast.svelte'
+  import { describeKeyboardError, keyboardStore } from '../stores'
+
+  const NO_LEDS: LedIndicator = { num_lock: false, caps_lock: false, scroll_lock: false, compose: false, kana: false }
+  const NO_MOUSE: MouseButtons = { button1: false, button2: false, button3: false, button4: false, button5: false, button6: false, button7: false, button8: false }
+  const NO_STATE: StateBits = { modifiers: { ...NO_MODIFIERS }, leds: NO_LEDS, mouse: NO_MOUSE }
+
+  const EMPTY: Fork = {
+    trigger: 'No',
+    negative_output: 'No',
+    positive_output: 'No',
+    match_any: structuredClone(NO_STATE),
+    match_none: structuredClone(NO_STATE),
+    kept_modifiers: { ...NO_MODIFIERS },
+    bindable: false,
+  }
+
+  const MODS = [
+    ['left_ctrl', 'LCtl'],
+    ['left_shift', 'LSft'],
+    ['left_alt', 'LAlt'],
+    ['left_gui', 'LGui'],
+    ['right_ctrl', 'RCtl'],
+    ['right_shift', 'RSft'],
+    ['right_alt', 'RAlt'],
+    ['right_gui', 'RGui'],
+  ] as const satisfies readonly (readonly [keyof ModifierCombination, string])[]
+
+  type Field = 'trigger' | 'positive_output' | 'negative_output'
+
+  let picking = $state<{ slot: number, field: Field } | null>(null)
+  let advancedOpen = $state<number | null>(null)
+
+  const caps = $derived(keyboardStore.device?.capabilities)
+  const forks = $derived(keyboardStore.config?.forks ?? [])
+  const used = $derived(forks.map((f, slot) => ({ fork: f, slot })).filter(e => e.fork.trigger !== 'No'))
+  const firstFree = $derived(forks.findIndex(f => f.trigger === 'No'))
+
+  function save(slot: number, fork: Fork) {
+    void keyboardStore.setFork(slot, fork).mapErr(e => toast.error(describeKeyboardError(e)))
+  }
+
+  function remove(slot: number) {
+    save(slot, structuredClone(EMPTY))
+    toast.success(`Cleared override ${slot}`)
+  }
+
+  function apply(action: KeyAction) {
+    const target = picking
+    if (!target) return
+    picking = null
+    const fork = forks[target.slot]
+    if (!fork) return
+    if (action === 'Transparent') {
+      toast.warning('An override cannot be transparent')
+      return
+    }
+    save(target.slot, { ...fork, [target.field]: action })
+  }
+
+  function toggleMod(slot: number, side: 'match_any' | 'match_none' | 'kept', flag: keyof ModifierCombination) {
+    const fork = forks[slot]
+    if (!fork) return
+    if (side === 'kept') {
+      const kept = { ...fork.kept_modifiers, [flag]: !fork.kept_modifiers[flag] }
+      save(slot, { ...fork, kept_modifiers: kept })
+      return
+    }
+    const state = fork[side]
+    const modifiers = { ...state.modifiers, [flag]: !state.modifiers[flag] }
+    save(slot, { ...fork, [side]: { ...state, modifiers } })
+  }
+
+  function toggleCaps(slot: number, side: 'match_any' | 'match_none') {
+    const fork = forks[slot]
+    if (!fork) return
+    const state = fork[side]
+    const leds = { ...state.leds, caps_lock: !state.leds.caps_lock }
+    save(slot, { ...fork, [side]: { ...state, leds } })
+  }
+
+  const FIELD_TITLES: Record<Field, string> = {
+    trigger: 'Trigger key',
+    positive_output: 'Output when the condition matches',
+    negative_output: 'Output otherwise',
+  }
+
+  const pickSubtitle = $derived.by(() => {
+    if (!picking) return ''
+    if (picking.field === 'trigger') return `Override ${picking.slot} · the key that activates this override`
+    return `Override ${picking.slot} · currently ${keyActionText(forks[picking.slot]?.[picking.field] ?? 'No')}`
+  })
+</script>
+
+{#snippet keyChip(slot: number, field: Field, action: KeyAction, brand: boolean)}
+  <button
+    class={[
+      `
+        inline-flex h-[38px] min-w-10 cursor-pointer items-center justify-center
+        rounded-[7px] px-2 text-sm font-bold
+      `,
+      brand
+        ? 'border-2 border-brand bg-brand-tint text-brand-darker'
+        : 'border border-base-300 bg-base-100 text-foreground',
+    ]}
+    type='button'
+    title={FIELD_TITLES[field]}
+    onclick={() => (picking = { slot, field })}
+  >
+    {action === 'No' ? '—' : capLegend(action, caps).main}
+  </button>
+{/snippet}
+
+{#snippet modChips(slot: number, side: 'match_any' | 'match_none' | 'kept', mods: ModifierCombination)}
+  <span class='inline-flex flex-wrap gap-1'>
+    {#each MODS as [flag, label] (flag)}
+      <button
+        class={[
+          `
+            inline-flex h-6.5 cursor-pointer items-center rounded-md border
+            px-1.5 font-mono text-[11px] font-bold transition-colors
+          `,
+          mods[flag]
+            ? 'border-brand bg-brand-tint text-brand-darker'
+            : `
+              border-border text-muted-foreground
+              hover:text-foreground
+            `,
+        ]}
+        type='button'
+        aria-pressed={mods[flag]}
+        onclick={() => toggleMod(slot, side, flag)}
+      >
+        {label}
+      </button>
+    {/each}
+  </span>
+{/snippet}
+
+<ScreenScroll
+  title='Key overrides'
+  desc='A fork sends one of two actions, decided by which modifiers are held.'
+>
+  {#snippet actions()}
+    <Button
+      variant='brand'
+      disabled={firstFree < 0}
+      title={firstFree < 0 ? 'Every override slot is in use' : 'Add an override'}
+      onclick={() => (picking = { slot: firstFree, field: 'trigger' })}
+    >
+      <Icon icon='lucide:plus' width={15} height={15} />
+      New override
+    </Button>
+  {/snippet}
+
+  {#if (caps?.max_forks ?? 0) === 0}
+    <Card>
+      <p class='py-3 text-center text-[13px] text-muted-foreground'>
+        This firmware was built without key overrides.
+      </p>
+    </Card>
+  {:else}
+    <div class='flex flex-col gap-3'>
+      {#each used as entry (entry.slot)}
+        {@const fork = entry.fork}
+        <Card class='flex flex-col gap-3'>
+          <div class='flex flex-wrap items-center gap-2.5'>
+            <span class='text-xs text-muted-foreground'>When</span>
+            {@render keyChip(entry.slot, 'trigger', fork.trigger, false)}
+            <span class='text-xs text-muted-foreground'>is pressed with</span>
+            {@render modChips(entry.slot, 'match_any', fork.match_any.modifiers)}
+            <button
+              class={[
+                `
+                  inline-flex h-6.5 cursor-pointer items-center gap-1 rounded-md
+                  border px-1.5 text-[11px] font-bold transition-colors
+                `,
+                fork.match_any.leds.caps_lock
+                  ? 'border-brand bg-brand-tint text-brand-darker'
+                  : `
+                    border-border text-muted-foreground
+                    hover:text-foreground
+                  `,
+              ]}
+              type='button'
+              aria-pressed={fork.match_any.leds.caps_lock}
+              title='Also match while the Caps Lock light is on'
+              onclick={() => toggleCaps(entry.slot, 'match_any')}
+            >
+              <Icon icon='lucide:lightbulb' width={11} height={11} />
+              Caps
+            </button>
+            <div class='ml-auto flex items-center gap-1'>
+              <IconBtn
+                icon='lucide:settings-2'
+                title='Advanced'
+                size={32}
+                active={advancedOpen === entry.slot}
+                onclick={() => (advancedOpen = advancedOpen === entry.slot ? null : entry.slot)}
+              />
+              <IconBtn
+                icon='lucide:trash-2'
+                title='Delete override'
+                size={32}
+                onclick={() => remove(entry.slot)}
+              />
+            </div>
+          </div>
+
+          <div class='flex flex-wrap items-center gap-2.5'>
+            <span class='text-xs text-muted-foreground'>matched</span>
+            <Icon class='text-brand' icon='lucide:chevron-right' width={16} height={16} />
+            {@render keyChip(entry.slot, 'positive_output', fork.positive_output, true)}
+            <span class='ml-3 text-xs text-muted-foreground'>otherwise</span>
+            <Icon class='text-muted-foreground' icon='lucide:chevron-right' width={16} height={16} />
+            {@render keyChip(entry.slot, 'negative_output', fork.negative_output, false)}
+          </div>
+
+          {#if advancedOpen === entry.slot}
+            <div class='
+              flex flex-col gap-2.5 border-t border-border pt-3 text-xs
+            '>
+              <div class='flex flex-wrap items-center gap-2.5'>
+                <span class='w-30 font-semibold text-foreground'>Suppress when</span>
+                {@render modChips(entry.slot, 'match_none', fork.match_none.modifiers)}
+                <span class='text-muted-foreground'>
+                  Any of these held keeps the override off.
+                </span>
+              </div>
+              <div class='flex flex-wrap items-center gap-2.5'>
+                <span class='w-30 font-semibold text-foreground'>Keep modifiers</span>
+                {@render modChips(entry.slot, 'kept', fork.kept_modifiers)}
+                <span class='text-muted-foreground'>
+                  Matched modifiers are swallowed unless kept here.
+                </span>
+              </div>
+              <div class='flex flex-wrap items-center gap-2.5'>
+                <span class='w-30 font-semibold text-foreground'>Chainable</span>
+                <button
+                  class={[
+                    `
+                      inline-flex h-6.5 cursor-pointer items-center rounded-md
+                      border px-2 text-[11px] font-bold transition-colors
+                    `,
+                    fork.bindable
+                      ? 'border-brand bg-brand-tint text-brand-darker'
+                      : `
+                        border-border text-muted-foreground
+                        hover:text-foreground
+                      `,
+                  ]}
+                  type='button'
+                  aria-pressed={fork.bindable}
+                  onclick={() => save(entry.slot, { ...fork, bindable: !fork.bindable })}
+                >
+                  {fork.bindable ? 'on' : 'off'}
+                </button>
+                <span class='text-muted-foreground'>
+                  Lets this override's output trigger other overrides.
+                </span>
+              </div>
+            </div>
+          {/if}
+        </Card>
+      {/each}
+
+      {#if used.length === 0}
+        <Card>
+          <p class='py-3 text-center text-xs text-muted-foreground'>
+            No key overrides yet. Shift+Backspace → Delete is the classic one.
+          </p>
+        </Card>
+      {/if}
+    </div>
+
+    <p class='mt-3.5 text-xs text-muted-foreground'>
+      This firmware has {forks.length} override slots. An override with no
+      modifier condition always takes its “matched” branch.
+    </p>
+  {/if}
+</ScreenScroll>
+
+{#if picking}
+  <Overlay
+    title={FIELD_TITLES[picking.field]}
+    subtitle={pickSubtitle}
+    onclose={() => (picking = null)}
+  >
+    <KeycodeSelect {caps} onpick={apply} />
+  </Overlay>
+{/if}

--- a/src/pages/Forks.svelte
+++ b/src/pages/Forks.svelte
@@ -164,7 +164,7 @@
     </Button>
   {/snippet}
 
-  {#if (caps?.max_forks ?? 0) === 0}
+  {#if forks.length === 0}
     <Card>
       <p class='py-3 text-center text-[13px] text-muted-foreground'>
         This firmware was built without key overrides.

--- a/src/pages/Keymap.svelte
+++ b/src/pages/Keymap.svelte
@@ -155,10 +155,10 @@
   {/if}
 
   <!-- Wider than the design's 1000px: the firmware's catalog has eight groups
-       where the mock had five, and the rail would clip its last tab. The height
-       is fixed so switching tabs never reflows the board above it — measured
-       against Basic, the tallest tab, so it is snug rather than arbitrary.
-       Shorter tabs leave slack; taller content scrolls. -->
+       where the mock had five, and the category row would clip its last tab. The
+       height is fixed so switching tabs never reflows the board above it —
+       measured against Basic, the tallest tab, so it is snug rather than
+       arbitrary. Shorter tabs leave slack; taller content scrolls. -->
   <div class='flex h-[380px] min-h-0 justify-center'>
     <div class='flex min-h-0 w-full max-w-[1200px]'>
       <KeycodeSelect {caps} panel onpick={assign}>

--- a/src/pages/Keymap.svelte
+++ b/src/pages/Keymap.svelte
@@ -28,6 +28,8 @@
   const history = new History()
 
   const caps = $derived(keyboardStore.device?.capabilities)
+  /// Vial has no default-layer command, so the setter affordance goes away.
+  const vial = $derived(keyboardStore.device?.protocol === 'vial')
   const variants = $derived(renderVariants(keyboardStore.device?.layout, caps))
   const variantIdx = $derived(
     pickedVariant ?? keyboardStore.device?.layout.default_variant ?? 0,
@@ -121,7 +123,7 @@
       {layer}
       defaultLayer={keyboardStore.config?.defaultLayer}
       onselect={switchLayer}
-      onsetdefault={setDefaultLayer}
+      onsetdefault={vial ? undefined : setDefaultLayer}
     />
     <div class='flex flex-1 justify-end gap-0.5'>
       <IconBtn

--- a/src/pages/Keymap.svelte
+++ b/src/pages/Keymap.svelte
@@ -154,11 +154,8 @@
     />
   {/if}
 
-  <!-- Wider than the design's 1000px: the firmware's catalog has eight groups
-       where the mock had five, and the category row would clip its last tab. The
-       height is fixed so switching tabs never reflows the board above it —
-       measured against Basic, the tallest tab, so it is snug rather than
-       arbitrary. Shorter tabs leave slack; taller content scrolls. -->
+  <!-- Fixed height, sized to Basic — the tallest tab — so switching tabs never
+       reflows the board above it. -->
   <div class='flex h-[380px] min-h-0 justify-center'>
     <div class='flex min-h-0 w-full max-w-[1200px]'>
       <KeycodeSelect {caps} panel onpick={assign}>

--- a/src/pages/Keymap.svelte
+++ b/src/pages/Keymap.svelte
@@ -1,9 +1,11 @@
 <script lang='ts'>
   import type { KeyAction, Variant } from '../rynk'
   import Board from '../components/Board.svelte'
+  import EncoderOverlay from '../components/EncoderOverlay.svelte'
   import KeycodeSelect from '../components/KeycodeSelect.svelte'
   import LayerTabs from '../components/LayerTabs.svelte'
   import IconBtn from '../components/ui/IconBtn.svelte'
+  import Select from '../components/ui/Select.svelte'
   import { drag } from '../lib/drag.svelte'
   import { History } from '../lib/history.svelte'
   import { renderVariants } from '../lib/layout'
@@ -19,15 +21,27 @@
 
   let selected = $state<{ row: number, col: number } | null>(null)
   let autoAdvance = $state(false)
+  /// null until the user switches away from the firmware's default variant.
+  let pickedVariant = $state<number | null>(null)
+  let editingEncoder = $state<number | null>(null)
 
   const history = new History()
 
   const caps = $derived(keyboardStore.device?.capabilities)
   const variants = $derived(renderVariants(keyboardStore.device?.layout, caps))
-  const variant = $derived<Variant | undefined>(
-    variants[keyboardStore.device?.layout.default_variant ?? 0] ?? variants[0],
+  const variantIdx = $derived(
+    pickedVariant ?? keyboardStore.device?.layout.default_variant ?? 0,
   )
+  const variant = $derived<Variant | undefined>(variants[variantIdx] ?? variants[0])
   const actions = $derived(keyboardStore.config?.keymap[layer] ?? [])
+  const hasEncoders = $derived((keyboardStore.config?.encoders.length ?? 0) > 0)
+
+  function setDefaultLayer(next: number) {
+    void keyboardStore.setDefaultLayer(next).match(
+      () => toast.success(`Layer ${next} is now the default`),
+      e => toast.error(describeKeyboardError(e)),
+    )
+  }
 
   function switchLayer(next: number) {
     onlayer(next)
@@ -92,11 +106,22 @@
 
 <div class='flex min-h-0 min-w-0 flex-1 flex-col gap-[14px] p-[14px] pb-4'>
   <div class='flex flex-none items-center'>
-    <div class='flex-1'></div>
+    <div class='flex flex-1 items-center'>
+      {#if variants.length > 1}
+        <Select
+          items={variants.map((v, i) => ({ value: String(i), label: v.name || `Variant ${i}` }))}
+          value={String(variantIdx)}
+          label='Layout variant'
+          onchange={v => (pickedVariant = Number(v))}
+        />
+      {/if}
+    </div>
     <LayerTabs
       count={caps?.num_layers ?? 1}
       {layer}
+      defaultLayer={keyboardStore.config?.defaultLayer}
       onselect={switchLayer}
+      onsetdefault={setDefaultLayer}
     />
     <div class='flex flex-1 justify-end gap-0.5'>
       <IconBtn
@@ -125,6 +150,7 @@
       {selected}
       onselect={(row, col) => { selected = { row, col } }}
       onassign={dropOn}
+      onencoder={hasEncoders ? id => (editingEncoder = id) : undefined}
     />
   {/if}
 
@@ -156,3 +182,11 @@
     </div>
   </div>
 </div>
+
+{#if editingEncoder !== null}
+  <EncoderOverlay
+    encoder={editingEncoder}
+    {layer}
+    onclose={() => (editingEncoder = null)}
+  />
+{/if}

--- a/src/pages/Morses.svelte
+++ b/src/pages/Morses.svelte
@@ -1,0 +1,391 @@
+<script lang='ts'>
+  import type { MorseStep } from '../lib/morse'
+  import type { Action, KeyAction, Morse, MorseMode, MorseProfile } from '../rynk'
+  import Icon from '@iconify/svelte'
+  import KeycodeSelect from '../components/KeycodeSelect.svelte'
+  import Button from '../components/ui/Button.svelte'
+  import Card from '../components/ui/Card.svelte'
+  import IconBtn from '../components/ui/IconBtn.svelte'
+  import Overlay from '../components/ui/Overlay.svelte'
+  import ScreenScroll from '../components/ui/ScreenScroll.svelte'
+  import Select from '../components/ui/Select.svelte'
+  import { asAction } from '../lib/keycatalog'
+  import { actionLabel } from '../lib/keycode'
+  import { decodePattern, DOUBLE_TAP, encodePattern, HOLD, HOLD_AFTER_TAP, MAX_PATTERN_STEPS, patternName, TAP } from '../lib/morse'
+  import { toast } from '../lib/toast.svelte'
+  import { describeKeyboardError, keyboardStore } from '../stores'
+
+  const PRESETS = [TAP, HOLD, DOUBLE_TAP, HOLD_AFTER_TAP]
+
+  const EMPTY_PROFILE: MorseProfile = {
+    unilateral_tap: undefined,
+    enable_flow_tap: undefined,
+    mode: undefined,
+    hold_timeout_ms: undefined,
+    gap_timeout_ms: undefined,
+    quick_tap_timeout_ms: undefined,
+  }
+
+  /// Set while the action picker overlay is open: which slot, and which
+  /// pattern the picked action will be bound to.
+  let picking = $state<{ slot: number, pattern: number } | null>(null)
+  /// Custom-pattern draft, one card at a time.
+  let building = $state<{ slot: number, steps: MorseStep[] } | null>(null)
+  /// Which card shows its timing profile.
+  let profileOpen = $state<number | null>(null)
+
+  const caps = $derived(keyboardStore.device?.capabilities)
+  const morses = $derived(keyboardStore.config?.morses ?? [])
+  const used = $derived(morses.map((m, slot) => ({ morse: m, slot })).filter(e => e.morse.actions.length > 0))
+  const firstFree = $derived(morses.findIndex(m => m.actions.length === 0))
+  const maxPatterns = $derived(caps?.max_patterns_per_key ?? 0)
+
+  function save(slot: number, morse: Morse) {
+    void keyboardStore.setMorse(slot, morse).mapErr(e => toast.error(describeKeyboardError(e)))
+  }
+
+  function remove(slot: number) {
+    save(slot, { profile: { ...EMPTY_PROFILE }, actions: [] })
+    toast.success(`Cleared morse ${slot}`)
+  }
+
+  function apply(action: KeyAction) {
+    const target = picking
+    if (!target) return
+    const plain = asAction(action)
+    if (plain === null) {
+      toast.warning('A morse action must be a plain action — not transparent or another morse key')
+      return
+    }
+    picking = null
+    const morse = morses[target.slot]
+    if (!morse) return
+    const at = morse.actions.findIndex(([p]) => p === target.pattern)
+    const actions: [number, Action][] = at >= 0
+      ? morse.actions.map(([p, a], i) => (i === at ? [p, plain] : [p, a]))
+      : [...morse.actions, [target.pattern, plain]]
+    save(target.slot, { ...morse, actions })
+  }
+
+  function dropPattern(slot: number, pattern: number) {
+    const morse = morses[slot]
+    if (!morse) return
+    save(slot, { ...morse, actions: morse.actions.filter(([p]) => p !== pattern) })
+  }
+
+  function pickFor(slot: number, pattern: number) {
+    const morse = morses[slot]
+    if (morse && morse.actions.every(([p]) => p !== pattern) && morse.actions.length >= maxPatterns) {
+      toast.warning(`This firmware allows ${maxPatterns} patterns per morse key`)
+      return
+    }
+    picking = { slot, pattern }
+  }
+
+  function confirmBuild() {
+    const draft = building
+    if (!draft || draft.steps.length === 0) return
+    const pattern = encodePattern(draft.steps)
+    const morse = morses[draft.slot]
+    if (morse?.actions.some(([p]) => p === pattern)) {
+      toast.warning(`${patternName(pattern)} is already bound on this key`)
+      return
+    }
+    building = null
+    pickFor(draft.slot, pattern)
+  }
+
+  function setProfile(slot: number, patch: Partial<MorseProfile>) {
+    const morse = morses[slot]
+    if (!morse) return
+    save(slot, { ...morse, profile: { ...morse.profile, ...patch } })
+  }
+
+  function timeout(slot: number, field: 'hold_timeout_ms' | 'gap_timeout_ms' | 'quick_tap_timeout_ms', raw: string) {
+    const n = raw === '' ? undefined : Math.max(0, Math.min(8191, Number(raw) || 0))
+    setProfile(slot, { [field]: n })
+  }
+
+  const TRI = [
+    { value: 'default', label: 'default' },
+    { value: 'on', label: 'on' },
+    { value: 'off', label: 'off' },
+  ]
+
+  function triValue(v: boolean | undefined): string {
+    return v === undefined ? 'default' : v ? 'on' : 'off'
+  }
+
+  function triSet(v: string): boolean | undefined {
+    return v === 'default' ? undefined : v === 'on'
+  }
+
+  const MODES = [
+    { value: 'default', label: 'default' },
+    { value: 'PermissiveHold', label: 'Permissive hold' },
+    { value: 'HoldOnOtherPress', label: 'Hold on other press' },
+    { value: 'Normal', label: 'On timeout' },
+  ]
+
+  const TIMEOUTS = [
+    { field: 'hold_timeout_ms', label: 'Hold timeout', hint: 'Held longer than this counts as a hold.' },
+    { field: 'gap_timeout_ms', label: 'Gap timeout', hint: 'A longer pause ends the tap sequence.' },
+    { field: 'quick_tap_timeout_ms', label: 'Quick tap', hint: 'Retapping within this repeats the tap.' },
+  ] as const
+</script>
+
+{#snippet patternChips(pattern: number)}
+  <span class='inline-flex items-center gap-1' title={patternName(pattern)}>
+    {#each decodePattern(pattern) as step, i (i)}
+      <span
+        class={[
+          'inline-block rounded-full bg-brand-dark',
+          step === 'tap' ? 'size-[7px]' : 'h-[7px] w-4',
+        ]}
+      ></span>
+    {/each}
+  </span>
+{/snippet}
+
+<ScreenScroll
+  title='Morse'
+  desc='Tap dance: one key runs a different action for each tap/hold pattern.'
+>
+  {#snippet actions()}
+    <Button
+      variant='brand'
+      disabled={firstFree < 0}
+      title={firstFree < 0 ? 'Every morse slot is in use' : 'Add a morse key'}
+      onclick={() => pickFor(firstFree, TAP)}
+    >
+      <Icon icon='lucide:plus' width={15} height={15} />
+      New morse key
+    </Button>
+  {/snippet}
+
+  {#if (caps?.max_morse ?? 0) === 0}
+    <Card>
+      <p class='py-3 text-center text-[13px] text-muted-foreground'>
+        This firmware was built without morse keys.
+      </p>
+    </Card>
+  {:else}
+    <div class='flex flex-col gap-3'>
+      {#each used as entry (entry.slot)}
+        {@const morse = entry.morse}
+        <Card class='flex flex-col gap-3'>
+          <div class='flex items-center gap-2.5'>
+            <span class='text-xs font-extrabold text-brand-darker'>Morse {entry.slot}</span>
+            <span class='text-[13px] text-muted-foreground'>
+              Assign with the <b class='text-brand-darker'>Morse {entry.slot}</b> keycode
+            </span>
+            <div class='ml-auto flex items-center gap-1'>
+              <IconBtn
+                icon='lucide:timer'
+                title='Timing profile'
+                size={32}
+                active={profileOpen === entry.slot}
+                onclick={() => (profileOpen = profileOpen === entry.slot ? null : entry.slot)}
+              />
+              <IconBtn
+                icon='lucide:trash-2'
+                title='Delete morse key'
+                size={32}
+                onclick={() => remove(entry.slot)}
+              />
+            </div>
+          </div>
+
+          <div class='flex flex-col gap-1.5'>
+            {#each morse.actions as [pattern, action] (pattern)}
+              <div class='
+                flex items-center gap-3 rounded-md bg-base-200 px-3 py-1.5
+              '>
+                {@render patternChips(pattern)}
+                <span class='w-24 text-xs text-muted-foreground'>{patternName(pattern)}</span>
+                <Icon class='text-brand' icon='lucide:chevron-right' width={15} height={15} />
+                <button
+                  class={`
+                    inline-flex h-8 min-w-12 cursor-pointer items-center
+                    justify-center rounded-[7px] border border-base-300
+                    bg-base-100 px-2 text-[13px] font-bold text-foreground
+                    hover:border-brand
+                  `}
+                  type='button'
+                  onclick={() => pickFor(entry.slot, pattern)}
+                >
+                  {actionLabel(action)}
+                </button>
+                <span class='flex-1'></span>
+                <IconBtn
+                  icon='lucide:x'
+                  title='Remove pattern'
+                  size={28}
+                  onclick={() => dropPattern(entry.slot, pattern)}
+                />
+              </div>
+            {/each}
+          </div>
+
+          <div class='flex flex-wrap items-center gap-1.5'>
+            {#each PRESETS as preset (preset)}
+              {@const taken = morse.actions.some(([p]) => p === preset)}
+              <button
+                class={`
+                  inline-flex h-7 cursor-pointer items-center gap-1.5 rounded-md
+                  border border-dashed border-border px-2.5 text-xs
+                  font-semibold text-muted-foreground
+                  hover:enabled:border-brand hover:enabled:text-brand-darker
+                  disabled:cursor-not-allowed disabled:opacity-45
+                `}
+                type='button'
+                disabled={taken}
+                title={taken ? `${patternName(preset)} is already bound` : `Bind ${patternName(preset)}`}
+                onclick={() => pickFor(entry.slot, preset)}
+              >
+                <Icon icon='lucide:plus' width={12} height={12} />
+                {patternName(preset)}
+              </button>
+            {/each}
+
+            {#if building?.slot === entry.slot}
+              {@const draft = building}
+              <span class='
+                inline-flex h-7 items-center gap-1.5 rounded-md bg-base-200 px-2
+              '>
+                {#if draft.steps.length}
+                  {@render patternChips(encodePattern(draft.steps))}
+                {:else}
+                  <span class='text-xs text-muted-foreground'>tap or hold…</span>
+                {/if}
+              </span>
+              <Button size='sm' disabled={draft.steps.length >= MAX_PATTERN_STEPS} onclick={() => { draft.steps = [...draft.steps, 'tap'] }}>Tap</Button>
+              <Button size='sm' disabled={draft.steps.length >= MAX_PATTERN_STEPS} onclick={() => { draft.steps = [...draft.steps, 'hold'] }}>Hold</Button>
+              <IconBtn
+                icon='lucide:delete'
+                title='Remove last step'
+                size={28}
+                disabled={draft.steps.length === 0}
+                onclick={() => { draft.steps = draft.steps.slice(0, -1) }}
+              />
+              <IconBtn
+                icon='lucide:check'
+                title='Pick the action for this pattern'
+                size={28}
+                disabled={draft.steps.length === 0}
+                onclick={confirmBuild}
+              />
+              <IconBtn
+                icon='lucide:x'
+                title='Cancel'
+                size={28}
+                onclick={() => (building = null)}
+              />
+            {:else}
+              <button
+                class={`
+                  inline-flex h-7 cursor-pointer items-center gap-1.5 rounded-md
+                  border border-dashed border-border px-2.5 text-xs
+                  font-semibold text-muted-foreground
+                  hover:border-brand hover:text-brand-darker
+                `}
+                type='button'
+                onclick={() => (building = { slot: entry.slot, steps: [] })}
+              >
+                <Icon icon='lucide:plus' width={12} height={12} />
+                Custom…
+              </button>
+            {/if}
+          </div>
+
+          {#if profileOpen === entry.slot}
+            <div class='
+              flex flex-col gap-2.5 border-t border-border pt-3 text-[13px]
+            '>
+              <div class='flex items-center gap-3'>
+                <span class='w-28 font-semibold text-foreground'>Decision mode</span>
+                <Select
+                  items={MODES}
+                  value={morse.profile.mode ?? 'default'}
+                  label='Decision mode'
+                  onchange={v => setProfile(entry.slot, { mode: v === 'default' ? undefined : v as MorseMode })}
+                />
+                <span class='text-xs text-muted-foreground'>
+                  How a press decides between tap and hold.
+                </span>
+              </div>
+              {#each TIMEOUTS as t (t.field)}
+                <div class='flex items-center gap-3'>
+                  <span class='w-28 font-semibold text-foreground'>{t.label}</span>
+                  <input
+                    class={`
+                      h-8 w-24 rounded-md border border-input bg-background
+                      px-2.5 font-mono text-[12.5px] text-foreground
+                      outline-none
+                    `}
+                    type='number'
+                    min='0'
+                    max='8191'
+                    placeholder='default'
+                    aria-label={t.label}
+                    value={morse.profile[t.field] ?? ''}
+                    onchange={e => timeout(entry.slot, t.field, e.currentTarget.value)}
+                  />
+                  <span class='text-xs text-muted-foreground'>ms · {t.hint}</span>
+                </div>
+              {/each}
+              <div class='flex items-center gap-3'>
+                <span class='w-28 font-semibold text-foreground'>Unilateral tap</span>
+                <Select
+                  items={TRI}
+                  value={triValue(morse.profile.unilateral_tap)}
+                  label='Unilateral tap'
+                  onchange={v => setProfile(entry.slot, { unilateral_tap: triSet(v) })}
+                />
+                <span class='text-xs text-muted-foreground'>
+                  A same-hand key after this one forces a tap.
+                </span>
+              </div>
+              <div class='flex items-center gap-3'>
+                <span class='w-28 font-semibold text-foreground'>Flow tap</span>
+                <Select
+                  items={TRI}
+                  value={triValue(morse.profile.enable_flow_tap)}
+                  label='Flow tap'
+                  onchange={v => setProfile(entry.slot, { enable_flow_tap: triSet(v) })}
+                />
+                <span class='text-xs text-muted-foreground'>
+                  Fast typing resolves this key as a tap.
+                </span>
+              </div>
+            </div>
+          {/if}
+        </Card>
+      {/each}
+
+      {#if used.length === 0}
+        <Card>
+          <p class='py-3 text-center text-xs text-muted-foreground'>
+            No morse keys yet.
+          </p>
+        </Card>
+      {/if}
+    </div>
+
+    <p class='mt-3.5 text-xs text-muted-foreground'>
+      This firmware has {morses.length} morse slots, each holding up to
+      {maxPatterns} patterns of at most {MAX_PATTERN_STEPS} steps. Timing
+      fields left at “default” inherit the keyboard-wide values.
+    </p>
+  {/if}
+</ScreenScroll>
+
+{#if picking}
+  <Overlay
+    title='{patternName(picking.pattern)} action'
+    subtitle='Choose what morse {picking.slot} does on {patternName(picking.pattern).toLowerCase()}.'
+    onclose={() => (picking = null)}
+  >
+    <KeycodeSelect {caps} onpick={apply} />
+  </Overlay>
+{/if}

--- a/src/pages/Morses.svelte
+++ b/src/pages/Morses.svelte
@@ -163,7 +163,7 @@
     </Button>
   {/snippet}
 
-  {#if (caps?.max_morse ?? 0) === 0}
+  {#if morses.length === 0}
     <Card>
       <p class='py-3 text-center text-[13px] text-muted-foreground'>
         This firmware was built without morse keys.

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -1,9 +1,11 @@
 <script lang='ts'>
+  import type { KeyboardConfig } from '../stores'
   import Icon from '@iconify/svelte'
   import { isTauri } from '@tauri-apps/api/core'
   import logo from '../assets/img/logo.svg'
   import Button from '../components/ui/Button.svelte'
   import Card from '../components/ui/Card.svelte'
+  import ConfirmOverlay from '../components/ui/ConfirmOverlay.svelte'
   import Pill from '../components/ui/Pill.svelte'
   import Row from '../components/ui/Row.svelte'
   import ScreenScroll from '../components/ui/ScreenScroll.svelte'
@@ -11,7 +13,11 @@
   import Unsupported from '../components/ui/Unsupported.svelte'
   import { theme } from '../lib/theme.svelte'
   import { toast } from '../lib/toast.svelte'
-  import { keyboardStore } from '../stores'
+  import { describeKeyboardError, keyboardStore } from '../stores'
+
+  let fileInput = $state<HTMLInputElement | null>(null)
+  /// Parsed and waiting for the user to confirm the overwrite.
+  let pending = $state<KeyboardConfig | null>(null)
 
   function exportConfig() {
     const device = keyboardStore.device
@@ -30,6 +36,44 @@
     a.click()
     URL.revokeObjectURL(url)
     toast.success(`Exported ${a.download}`)
+  }
+
+  /// Only the presence of the tables is checked here; the store validates
+  /// every dimension against the live capabilities before writing.
+  function isConfigShaped(v: unknown): v is KeyboardConfig {
+    if (typeof v !== 'object' || v === null) return false
+    const c = v as Record<string, unknown>
+    return Array.isArray(c.keymap) && Array.isArray(c.combos)
+      && Array.isArray(c.macros) && Array.isArray(c.morses)
+      && Array.isArray(c.forks) && Array.isArray(c.encoders)
+      && typeof c.defaultLayer === 'number'
+      && typeof c.behavior === 'object' && c.behavior !== null
+  }
+
+  async function readBackup(file: File) {
+    try {
+      const parsed: unknown = JSON.parse(await file.text())
+      const config = (parsed as { config?: unknown }).config ?? parsed
+      if (!isConfigShaped(config)) {
+        toast.error('Not a backup this app exported', 'The file is missing the configuration tables.')
+        return
+      }
+      pending = config
+    }
+    catch {
+      toast.error('Could not read the backup', 'The file is not valid JSON.')
+    }
+  }
+
+  function applyImport() {
+    const config = pending
+    pending = null
+    if (!config) return
+    toast.info('Restoring backup…')
+    void keyboardStore.importConfig(config).match(
+      () => toast.success('Backup restored'),
+      e => toast.error('Restore failed', describeKeyboardError(e)),
+    )
   }
 </script>
 
@@ -86,17 +130,36 @@
       <div>
         <div class='text-[13.5px] font-semibold text-foreground'>Backup keymap</div>
         <div class='text-xs text-muted-foreground'>
-          Export the keyboard's current configuration as a .json file.
+          Export the keyboard's configuration, or restore an exported backup.
         </div>
       </div>
-      <Button
-        class='ml-auto'
-        disabled={!keyboardStore.config}
-        onclick={exportConfig}
-      >
-        <Icon icon='lucide:save' width={15} height={15} />
-        Export
-      </Button>
+      <div class='ml-auto flex gap-2'>
+        <input
+          class='hidden'
+          type='file'
+          accept='.json,application/json'
+          bind:this={fileInput}
+          onchange={(e) => {
+            const file = e.currentTarget.files?.[0]
+            e.currentTarget.value = ''
+            if (file) void readBackup(file)
+          }}
+        />
+        <Button
+          disabled={!keyboardStore.config}
+          onclick={() => fileInput?.click()}
+        >
+          <Icon icon='lucide:folder-open' width={15} height={15} />
+          Import
+        </Button>
+        <Button
+          disabled={!keyboardStore.config}
+          onclick={exportConfig}
+        >
+          <Icon icon='lucide:save' width={15} height={15} />
+          Export
+        </Button>
+      </div>
     </Row>
   </Card>
 
@@ -119,3 +182,16 @@
     </div>
   </Card>
 </ScreenScroll>
+
+{#if pending}
+  <ConfirmOverlay
+    title='Restore this backup?'
+    confirmLabel='Overwrite keyboard'
+    onconfirm={applyImport}
+    onclose={() => (pending = null)}
+  >
+    Everything on the keyboard — keymap, combos, macros, morse keys, and
+    timing — is replaced with the backup's contents. A backup from a
+    different keyboard model is refused before anything is written.
+  </ConfirmOverlay>
+{/if}

--- a/src/pages/Tester.svelte
+++ b/src/pages/Tester.svelte
@@ -1,0 +1,133 @@
+<script lang='ts'>
+  import type { Variant } from '../rynk'
+  import Icon from '@iconify/svelte'
+  import { SvelteSet } from 'svelte/reactivity'
+  import Board from '../components/Board.svelte'
+  import Button from '../components/ui/Button.svelte'
+  import Card from '../components/ui/Card.svelte'
+  import UnlockOverlay from '../components/UnlockOverlay.svelte'
+  import { renderVariants } from '../lib/layout'
+  import { pressedCells } from '../lib/matrix'
+  import { keyboardStore } from '../stores'
+
+  const POLL_MS = 120
+
+  let unlocking = $state(false)
+  /// Cells seen pressed since the page opened, so a flaky switch leaves a trace.
+  const seen = new SvelteSet<string>()
+
+  const caps = $derived(keyboardStore.device?.capabilities)
+  const status = $derived(keyboardStore.status)
+  const locked = $derived(status?.lockStatus.locked ?? true)
+  /// Permanently locked firmware has no challenge to hold, so no way in.
+  const lockable = $derived((status?.lockStatus.key_positions.length ?? 0) > 0)
+  const variants = $derived(renderVariants(keyboardStore.device?.layout, caps))
+  const variant = $derived<Variant | undefined>(
+    variants[keyboardStore.device?.layout.default_variant ?? 0] ?? variants[0],
+  )
+  const pressed = $derived.by(() => {
+    const state = status?.matrixState
+    if (!state || !caps) return new Set<string>()
+    return pressedCells(state, caps.num_rows, caps.num_cols)
+  })
+
+  $effect(() => {
+    for (const cell of pressed) seen.add(cell)
+  })
+
+  $effect(() => {
+    if (locked) return
+    let cancelled = false
+    let timer: ReturnType<typeof setTimeout>
+    // Self-scheduling: each poll is a queued client call, and a slow link must
+    // not pile up a burst of them.
+    const poll = () => {
+      void keyboardStore.refreshMatrixState().match(
+        () => { if (!cancelled) timer = setTimeout(poll, POLL_MS) },
+        () => { if (!cancelled) timer = setTimeout(poll, POLL_MS * 8) },
+      )
+    }
+    poll()
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+    }
+  })
+</script>
+
+<div class='flex min-h-0 min-w-0 flex-1 flex-col gap-[14px] p-[14px] pb-4'>
+  <div class='flex flex-none items-center justify-between'>
+    <div>
+      <h1 class='text-lg font-extrabold tracking-tight text-foreground'>
+        Matrix tester
+      </h1>
+      <p class='text-xs text-muted-foreground'>
+        Press keys on the keyboard — live presses light up, and everything
+        pressed since the page opened stays marked.
+      </p>
+    </div>
+    <div class='flex items-center gap-4 text-xs text-muted-foreground'>
+      <span title='Keys seen pressed since the page opened'>
+        Tested <b class='text-foreground'>{seen.size}</b>
+        / {variant?.keys.length ?? 0}
+      </span>
+      <Button size='sm' disabled={seen.size === 0} onclick={() => seen.clear()}>
+        Reset
+      </Button>
+    </div>
+  </div>
+
+  {#if locked}
+    <Card class='flex flex-1 flex-col items-center justify-center gap-3'>
+      <Icon class='text-muted-foreground' icon='lucide:lock' width={28} height={28} />
+      <p class='max-w-105 text-center text-[13px] text-muted-foreground'>
+        Reading the key matrix is a security-sensitive command, so the
+        keyboard asks for a physical-presence check first.
+      </p>
+      {#if lockable}
+        <Button variant='brand' onclick={() => (unlocking = true)}>
+          <Icon icon='lucide:lock-open' width={15} height={15} />
+          Unlock keyboard
+        </Button>
+      {:else}
+        <p class='text-xs text-muted-foreground'>
+          This firmware has no unlock keys configured, so the lock is permanent.
+        </p>
+      {/if}
+    </Card>
+  {:else if variant}
+    <Board
+      {variant}
+      {caps}
+      layer={keyboardStore.config?.keymap[status?.currentLayer ?? 0] ?? []}
+      layerIndex={0}
+      selected={null}
+      {pressed}
+      marked={seen}
+      onselect={() => {}}
+      onassign={() => {}}
+    />
+    <div class='
+      flex flex-none items-center justify-center gap-5 text-xs
+      text-muted-foreground
+    '>
+      <span>Layer <b class='text-foreground'>{status?.currentLayer ?? 0}</b></span>
+      <span>WPM <b class='text-foreground'>{status?.wpm ?? 0}</b></span>
+      {#each [['Caps', status?.ledIndicator.caps_lock], ['Num', status?.ledIndicator.num_lock], ['Scroll', status?.ledIndicator.scroll_lock]] as [label, on] (label)}
+        <span class='inline-flex items-center gap-1.5'>
+          <span
+            class={[
+              'size-1.5 rounded-full',
+              on ? 'bg-ok-bright' : 'bg-muted-foreground/40',
+            ]}
+          ></span>
+          {label}
+        </span>
+      {/each}
+    </div>
+  {/if}
+</div>
+
+{#if unlocking}
+  <UnlockOverlay onclose={() => (unlocking = false)} />
+{/if}

--- a/src/rynk/core.ts
+++ b/src/rynk/core.ts
@@ -172,6 +172,28 @@ export async function connectClient(link: JsByteLink, wasm?: BufferSource, timeo
   return { client, major, minor }
 }
 
+/// Vial connects take the definition download with them, so the window is per
+/// whole handshake, not per exchange like the rynk probe's idle watchdog.
+const VIAL_CONNECT_TIMEOUT_MS = 15_000
+
+/// Vial path: no version probe — the transport already identified the protocol
+/// by the interface it found the device on. `connect_vial` handshakes and
+/// pulls the keyboard definition; a device that stops answering trips the
+/// deadline, and the caller's teardown closes the link, which unwinds the
+/// parked wasm task.
+export async function connectVial(link: JsByteLink, wasm?: BufferSource, timeoutMs = VIAL_CONNECT_TIMEOUT_MS) {
+  const core = await loadCore(0)
+  await core.default(wasm ? { module_or_path: wasm } : undefined)
+  const client = await withDeadline(core.connect_vial(link), timeoutMs, 'vial handshake timed out')
+  return { client }
+}
+
+/// The method surface the keyboard store drives — both wasm clients carry it
+/// with identical signatures, so the store stays protocol-blind.
+export type KeyboardClient
+  = | import('./wasm/rynk_wasm.js').RynkClient
+    | import('./wasm/rynk_wasm.js').VialClient
+
 /// The keycode tables the firmware understands, straight out of `rmk-types`.
 /// A host that keeps its own copy stops offering whatever the firmware gains
 /// next; a TS union cannot be iterated, so the wasm hands over the values.

--- a/src/rynk/index.ts
+++ b/src/rynk/index.ts
@@ -1,18 +1,35 @@
 import type { TauriByteLink } from './tauri'
-import type { WebHidLink, WebUsbLink } from './web'
+import type { HidProtocol, WebHidLink, WebUsbLink } from './web'
 import { isTauri } from '@tauri-apps/api/core'
-import { closeAllSessions, connectBle, connectTcp, connectUsb, discoverBle, discoverTcp, discoverUsb } from './tauri'
-import { grantedHidDevices, grantedUsbDevices, hidLabel, openHid, openUsb, usbLabel } from './web'
+import {
+  closeAllSessions,
+  connectBle,
+  connectTcp,
+  connectUsb,
+  connectVialHid,
+  discoverBle,
+  discoverTcp,
+  discoverUsb,
+  discoverVialHid,
+} from './tauri'
+import { grantedHidDevices, grantedUsbDevices, hidLabel, hidProtocol, openHid, openUsb, usbLabel } from './web'
 
 export type ByteLink = TauriByteLink | WebUsbLink | WebHidLink
+
+/// Which wire protocol a transport entry speaks — decided by the interface it
+/// was found on (rynk vendor interface / 0xFF14 vs the Vial 0xFF60 page), so
+/// no probe is needed to route the connect.
+export type Protocol = HidProtocol
 
 export interface ConnectedDevice {
   link: ByteLink
   label: string
+  protocol: Protocol
 }
 
 export interface TransportInfo {
   kind: 'usb' | 'ble' | 'tcp' | 'hid'
+  protocol: Protocol
   /// Stable across scans (USB device id / BLE id / socket address); identifies
   /// the live session so a rescan can leave it alone.
   id: string
@@ -34,6 +51,7 @@ export async function discover(): Promise<TransportInfo[]> {
     return [
       ...usbs.map((device, i) => ({
         kind: 'usb' as const,
+        protocol: 'rynk' as const,
         id: `usb:${device.vendorId}:${device.productId}:${device.serialNumber ?? i}`,
         label: usbLabel(device),
         connect: () => openUsb(device),
@@ -41,6 +59,7 @@ export async function discover(): Promise<TransportInfo[]> {
       })),
       ...hids.map(device => ({
         kind: 'hid' as const,
+        protocol: hidProtocol(device) ?? 'rynk',
         id: `hid:${device.vendorId}:${device.productId}:${device.productName}`,
         label: hidLabel(device),
         connect: () => openHid(device),
@@ -48,25 +67,41 @@ export async function discover(): Promise<TransportInfo[]> {
       })),
     ]
   }
-  const [usbs, bles, tcps] = await Promise.all([
+  const [usbs, bles, tcps, vials] = await Promise.all([
     discoverUsb().catch(() => []),
     discoverBle().catch(() => []),
     discoverTcp().catch(() => []),
+    discoverVialHid().catch(() => []),
   ])
   return [
-    ...usbs.map(u => ({ kind: 'usb' as const, id: u.id, label: u.name, connect: () => connectUsb(u.id, u.name) })),
+    ...usbs.map(u => ({
+      kind: 'usb' as const,
+      protocol: 'rynk' as const,
+      id: u.id,
+      label: u.name,
+      connect: () => connectUsb(u.id, u.name),
+    })),
     ...bles.map((b) => {
       const label = b.name ?? b.id
-      return { kind: 'ble' as const, id: b.id, label, connect: () => connectBle(b.id, label) }
+      return { kind: 'ble' as const, protocol: 'rynk' as const, id: b.id, label, connect: () => connectBle(b.id, label) }
     }),
     ...tcps.map((t) => {
-      return { kind: 'tcp' as const, id: t.addr, label: t.name, connect: () => connectTcp(t.addr, t.name) }
+      return { kind: 'tcp' as const, protocol: 'rynk' as const, id: t.addr, label: t.name, connect: () => connectTcp(t.addr, t.name) }
     }),
+    // A Vial keyboard the OS already bonded over Bluetooth surfaces from the
+    // same HID enumeration; `kind` keeps the connect screen's tabs honest.
+    ...vials.map(v => ({
+      kind: v.bluetooth ? 'hid' as const : 'usb' as const,
+      protocol: 'vial' as const,
+      id: v.id,
+      label: v.name,
+      connect: () => connectVialHid(v.id, v.name),
+    })),
   ]
 }
 
-export { connectClient, keycodeTables, withDeadline } from './core'
-export type { JsByteLink } from './core'
+export { connectClient, connectVial, keycodeTables, withDeadline } from './core'
+export type { JsByteLink, KeyboardClient } from './core'
 export { closeAllSessions }
 export type * from './wasm/rynk_wasm.js'
 export { canUseWebHid, canUseWebUsb, requestHidDevice, requestUsbDevice } from './web'

--- a/src/rynk/tauri.ts
+++ b/src/rynk/tauri.ts
@@ -21,6 +21,7 @@ export class TauriByteLink {
 interface UsbDeviceInfo { id: string, name: string }
 interface BleDeviceInfo { id: string, name: string | null }
 interface TcpDeviceInfo { addr: string, name: string }
+interface VialHidDeviceInfo { id: string, name: string, bluetooth: boolean }
 
 export async function discoverUsb(): Promise<UsbDeviceInfo[]> {
   return invoke<UsbDeviceInfo[]>('rynk_discover_usb')
@@ -34,14 +35,25 @@ export async function discoverTcp(): Promise<TcpDeviceInfo[]> {
   return invoke<TcpDeviceInfo[]>('rynk_discover_tcp')
 }
 
+/// Vial keyboards: HID interfaces on the 0xFF60 vendor page, USB or OS-bonded
+/// Bluetooth alike — hidapi enumerates both.
+export async function discoverVialHid(): Promise<VialHidDeviceInfo[]> {
+  return invoke<VialHidDeviceInfo[]>('vial_discover_hid')
+}
+
 export async function connectUsb(id: string, label: string): Promise<ConnectedDevice> {
   const session = await invoke<string>('rynk_connect_usb', { id })
-  return { link: new TauriByteLink(session, label), label }
+  return { link: new TauriByteLink(session, label), label, protocol: 'rynk' }
 }
 
 export async function connectBle(id: string, label: string): Promise<ConnectedDevice> {
   const session = await invoke<string>('rynk_connect_ble', { id })
-  return { link: new TauriByteLink(session, label), label }
+  return { link: new TauriByteLink(session, label), label, protocol: 'rynk' }
+}
+
+export async function connectVialHid(id: string, label: string): Promise<ConnectedDevice> {
+  const session = await invoke<string>('vial_connect_hid', { id })
+  return { link: new TauriByteLink(session, label), label, protocol: 'vial' }
 }
 
 export async function closeAllSessions(): Promise<void> {
@@ -50,5 +62,5 @@ export async function closeAllSessions(): Promise<void> {
 
 export async function connectTcp(addr: string, label: string): Promise<ConnectedDevice> {
   const session = await invoke<string>('rynk_connect_tcp', { addr })
-  return { link: new TauriByteLink(session, label), label }
+  return { link: new TauriByteLink(session, label), label, protocol: 'rynk' }
 }

--- a/src/rynk/web.ts
+++ b/src/rynk/web.ts
@@ -10,6 +10,13 @@ const RYNK_HID_USAGE = 0x61
 /// The firmware's collection is the only one on the report; report id 0.
 const RYNK_HID_REPORT_ID = 0
 
+/// The classic Via/Vial vendor usage — what a Vial keyboard (or an RMK build
+/// with the default `vial` feature) exposes. Same 32-byte report id 0 framing.
+const VIAL_HID_USAGE_PAGE = 0xFF60
+const VIAL_HID_USAGE = 0x61
+
+export type HidProtocol = 'rynk' | 'vial'
+
 /// The RMK vendor bulk interface — the class triple the firmware advertises
 /// (`RYNK_USB_INTERFACE_*` in rmk-types), matched instead of any VID/PID.
 const RYNK_USB_CLASS = 0xFF
@@ -233,7 +240,7 @@ export async function openUsb(device: USBDevice): Promise<ConnectedDevice> {
   }
   await device.claimInterface(iface.interfaceNumber)
   const label = usbLabel(device)
-  return { link: new WebUsbLink(device, iface, label), label }
+  return { link: new WebUsbLink(device, iface, label), label, protocol: 'rynk' }
 }
 
 /// Must run inside a click: the browser's own device picker needs the gesture.
@@ -256,16 +263,31 @@ export async function grantedUsbDevices(): Promise<USBDevice[]> {
   return devices.filter(d => vendorInterface(d) !== null)
 }
 
+/// Which protocol a granted HID device speaks, read off its collections.
+/// A device carrying both pages (a transitional firmware) counts as rynk.
+export function hidProtocol(device: HIDDevice): HidProtocol | null {
+  let vial = false
+  for (const c of device.collections) {
+    if (c.usagePage === RYNK_HID_USAGE_PAGE && c.usage === RYNK_HID_USAGE) return 'rynk'
+    if (c.usagePage === VIAL_HID_USAGE_PAGE && c.usage === VIAL_HID_USAGE) vial = true
+  }
+  return vial ? 'vial' : null
+}
+
 export async function openHid(device: HIDDevice): Promise<ConnectedDevice> {
   if (!device.opened) await device.open()
   const label = hidLabel(device)
-  return { link: new WebHidLink(device, label), label }
+  return { link: new WebHidLink(device, label), label, protocol: hidProtocol(device) ?? 'rynk' }
 }
 
 /// Must run inside a click: the browser's own device picker needs the gesture.
+/// Lists both rynk-HID and Vial keyboards; the grant's collections say which.
 export async function requestHidDevice(): Promise<HIDDevice> {
   const devices = await navigator.hid.requestDevice({
-    filters: [{ usagePage: RYNK_HID_USAGE_PAGE, usage: RYNK_HID_USAGE }],
+    filters: [
+      { usagePage: RYNK_HID_USAGE_PAGE, usage: RYNK_HID_USAGE },
+      { usagePage: VIAL_HID_USAGE_PAGE, usage: VIAL_HID_USAGE },
+    ],
   })
   const device = devices[0]
   if (!device) throw new Error('no keyboard chosen')
@@ -277,7 +299,5 @@ export async function requestHidDevice(): Promise<HIDDevice> {
 export async function grantedHidDevices(): Promise<HIDDevice[]> {
   if (!canUseWebHid()) return []
   const devices = await navigator.hid.getDevices().catch(() => [])
-  return devices.filter(d =>
-    d.collections.some(c => c.usagePage === RYNK_HID_USAGE_PAGE && c.usage === RYNK_HID_USAGE),
-  )
+  return devices.filter(d => hidProtocol(d) !== null)
 }

--- a/src/stores/keyboard/errors.test.ts
+++ b/src/stores/keyboard/errors.test.ts
@@ -38,7 +38,12 @@ describe('toKeyboardError', () => {
 
 describe('describeKeyboardError', () => {
   it('names the rejection code', () => {
-    expect(describeKeyboardError({ type: 'rynk', code: 'Locked' })).toBe('device rejected Locked')
+    expect(describeKeyboardError({ type: 'rynk', code: 'Busy' })).toBe('device rejected Busy')
+  })
+
+  it('points a locked rejection at the unlock flow', () => {
+    expect(describeKeyboardError({ type: 'rynk', code: 'Locked' }))
+      .toBe('keyboard is locked — unlock it from the top bar')
   })
 
   it('describes the non-rynk variants', () => {

--- a/src/stores/keyboard/errors.ts
+++ b/src/stores/keyboard/errors.ts
@@ -51,6 +51,7 @@ export function toKeyboardError(e: unknown): KeyboardError {
 /// Short, user-facing reason — for the status bar and the connect button.
 export function describeKeyboardError(e: KeyboardError): string {
   return match(e)
+    .with({ type: 'rynk', code: 'Locked' }, () => 'keyboard is locked — unlock it from the top bar')
     .with({ type: 'rynk' }, x => `device rejected ${x.code}`)
     .with({ type: 'transport' }, () => 'link lost')
     .with({ type: 'invalid' }, x => x.cause)

--- a/src/stores/keyboard/keyboard.svelte.ts
+++ b/src/stores/keyboard/keyboard.svelte.ts
@@ -119,8 +119,17 @@ async function fetchEncoders(client: RynkClient, caps: DeviceCapabilities): Prom
 
 async function fetchForks(client: RynkClient, caps: DeviceCapabilities): Promise<Fork[]> {
   const forks: Fork[] = []
+  // max_forks is the table's build-time capacity; the live table can be
+  // shorter, and the firmware answers a past-the-end read with Invalid.
   for (let i = 0; i < caps.max_forks; i++) {
-    forks.push(await client.get_fork(i))
+    try {
+      forks.push(await client.get_fork(i))
+    }
+    catch (e) {
+      const err = toKeyboardError(e)
+      if (err.type === 'rynk' && err.code === 'Invalid') break
+      throw e
+    }
   }
   return forks
 }
@@ -186,7 +195,7 @@ function invalid(cause: string): ResultAsync<void, KeyboardError> {
 
 /// A backup from another keyboard must not be half-written into this one, so
 /// every table is checked against the live capabilities before the first write.
-function validateConfigShape(config: KeyboardConfig, caps: DeviceCapabilities): string | null {
+function validateConfigShape(config: KeyboardConfig, caps: DeviceCapabilities, current: KeyboardConfig): string | null {
   if (config.keymap.length !== caps.num_layers)
     return `keymap: ${config.keymap.length} layers, expected ${caps.num_layers}`
   for (const [l, rows] of config.keymap.entries()) {
@@ -197,12 +206,15 @@ function validateConfigShape(config: KeyboardConfig, caps: DeviceCapabilities): 
         return `keymap layer ${l} row ${r}: ${row.length} cols, expected ${caps.num_cols}`
     }
   }
-  if (config.combos.length !== caps.max_combos)
-    return `combos: ${config.combos.length} slots, expected ${caps.max_combos}`
-  if (config.morses.length !== caps.max_morse)
-    return `morses: ${config.morses.length} slots, expected ${caps.max_morse}`
-  if (config.forks.length !== caps.max_forks)
-    return `forks: ${config.forks.length} slots, expected ${caps.max_forks}`
+  // Combo/morse/fork tables are sized by the live table, not by the caps
+  // maxima: those report build-time capacity, and the firmware rejects a
+  // write past the actual length.
+  if (config.combos.length !== current.combos.length)
+    return `combos: ${config.combos.length} slots, expected ${current.combos.length}`
+  if (config.morses.length !== current.morses.length)
+    return `morses: ${config.morses.length} slots, expected ${current.morses.length}`
+  if (config.forks.length !== current.forks.length)
+    return `forks: ${config.forks.length} slots, expected ${current.forks.length}`
   if (config.encoders.length !== caps.num_encoders)
     return `encoders: ${config.encoders.length}, expected ${caps.num_encoders}`
   if (config.encoders.some(layers => layers.length !== caps.num_layers))
@@ -548,7 +560,7 @@ class KeyboardStoreClass {
   importConfig(config: KeyboardConfig): ResultAsync<void, KeyboardError> {
     const caps = this.#device?.capabilities
     if (!this.#config || !caps) return invalid('not connected')
-    const shape = validateConfigShape(config, caps)
+    const shape = validateConfigShape(config, caps, this.#config)
     if (shape) return invalid(shape)
 
     return runCommand(async (c) => {

--- a/src/stores/keyboard/keyboard.svelte.ts
+++ b/src/stores/keyboard/keyboard.svelte.ts
@@ -8,11 +8,11 @@ import type {
   EncoderAction,
   Fork,
   KeyAction,
+  KeyboardClient,
   LockStatus,
   MatrixState,
   Morse,
   PeripheralStatus,
-  RynkClient,
   StorageResetMode,
 } from '../../rynk'
 import type { KeyboardError } from './errors'
@@ -20,11 +20,11 @@ import type { ConnectionState, KeyboardConfig, KeyboardDevice, KeyboardStatus } 
 import { err, errAsync, ResultAsync } from 'neverthrow'
 import { match, P } from 'ts-pattern'
 import { toast } from '../../lib/toast.svelte'
-import { connectClient } from '../../rynk'
+import { connectClient, connectVial } from '../../rynk'
 import { explainKeyboardError, toKeyboardError } from './errors'
 
 const session = {
-  client: null as RynkClient | null,
+  client: null as KeyboardClient | null,
   connected: null as ConnectedDevice | null,
   chain: Promise.resolve() as Promise<void>,
   topicsReady: false,
@@ -61,7 +61,7 @@ function enqueue<T>(
 }
 
 /// Commands and reads that need no optimistic update or rollback.
-function runCommand<T>(call: (c: RynkClient) => Promise<T>): ResultAsync<T, KeyboardError> {
+function runCommand<T>(call: (c: KeyboardClient) => Promise<T>): ResultAsync<T, KeyboardError> {
   return enqueue(() => {
     const client = session.client
     // Checked inside the chain, not at enqueue time: the link can die while queued.
@@ -72,7 +72,7 @@ function runCommand<T>(call: (c: RynkClient) => Promise<T>): ResultAsync<T, Keyb
 
 interface Mutation<T> {
   push: () => T
-  call: (c: RynkClient) => Promise<void>
+  call: (c: KeyboardClient) => Promise<void>
   undo: (snapshot: T) => void
 }
 
@@ -86,7 +86,7 @@ function runMutation<T>(m: Mutation<T>): ResultAsync<void, KeyboardError> {
   })
 }
 
-async function fetchKeymap(client: RynkClient, caps: DeviceCapabilities): Promise<KeyAction[][][]> {
+async function fetchKeymap(client: KeyboardClient, caps: DeviceCapabilities): Promise<KeyAction[][][]> {
   const keymap: KeyAction[][][] = []
   // read_all_keymap pages the whole thing; a single get_keymap_bulk caps at
   // max_bulk_keys and silently drops the tail of a larger layer.
@@ -105,7 +105,7 @@ async function fetchKeymap(client: RynkClient, caps: DeviceCapabilities): Promis
   return keymap
 }
 
-async function fetchEncoders(client: RynkClient, caps: DeviceCapabilities): Promise<EncoderAction[][]> {
+async function fetchEncoders(client: KeyboardClient, caps: DeviceCapabilities): Promise<EncoderAction[][]> {
   const encoders: EncoderAction[][] = []
   for (let e = 0; e < caps.num_encoders; e++) {
     const layers: EncoderAction[] = []
@@ -117,7 +117,7 @@ async function fetchEncoders(client: RynkClient, caps: DeviceCapabilities): Prom
   return encoders
 }
 
-async function fetchForks(client: RynkClient, caps: DeviceCapabilities): Promise<Fork[]> {
+async function fetchForks(client: KeyboardClient, caps: DeviceCapabilities): Promise<Fork[]> {
   const forks: Fork[] = []
   // max_forks is the table's build-time capacity; the live table can be
   // shorter, and the firmware answers a past-the-end read with Invalid.
@@ -134,7 +134,7 @@ async function fetchForks(client: RynkClient, caps: DeviceCapabilities): Promise
   return forks
 }
 
-async function fetchMacros(client: RynkClient, caps: DeviceCapabilities): Promise<number[]> {
+async function fetchMacros(client: KeyboardClient, caps: DeviceCapabilities): Promise<number[]> {
   // No upstream pager for macros: each chunk is exactly macro_chunk_size bytes,
   // zero-filled past the end, so walk the whole space by chunk.
   const out: number[] = []
@@ -146,7 +146,7 @@ async function fetchMacros(client: RynkClient, caps: DeviceCapabilities): Promis
   return out.slice(0, caps.macro_space_size)
 }
 
-async function fetchConfig(client: RynkClient, caps: DeviceCapabilities): Promise<KeyboardConfig> {
+async function fetchConfig(client: KeyboardClient, caps: DeviceCapabilities): Promise<KeyboardConfig> {
   const behavior = await client.get_behavior()
   const defaultLayer = await client.get_default_layer()
   const keymap = await fetchKeymap(client, caps)
@@ -158,7 +158,7 @@ async function fetchConfig(client: RynkClient, caps: DeviceCapabilities): Promis
   return { behavior, combos, defaultLayer, encoders, forks, keymap, macros, morses }
 }
 
-async function fetchStatus(client: RynkClient, caps: DeviceCapabilities): Promise<KeyboardStatus> {
+async function fetchStatus(client: KeyboardClient, caps: DeviceCapabilities): Promise<KeyboardStatus> {
   const lockStatus = await client.get_lock_status()
   const batteryStatus = caps.ble_enabled ? await client.get_battery_status() : 'Unavailable'
   const bleStatus = caps.ble_enabled ? await client.get_ble_status() : null
@@ -237,7 +237,7 @@ class KeyboardStoreClass {
   get config() { return this.#config }
   get status() { return this.#status }
 
-  private async startTopicLoop(client: RynkClient): Promise<void> {
+  private async startTopicLoop(client: KeyboardClient): Promise<void> {
     try {
       while (session.client === client) {
         const event = await client.next_topic()
@@ -261,7 +261,7 @@ class KeyboardStoreClass {
 
   /// `fromTopicLoop` marks the caller as the topic loop itself, so teardown
   /// skips awaiting it — awaiting your own promise deadlocks.
-  private async handleDeath(client: RynkClient, cause: KeyboardError, fromTopicLoop: boolean): Promise<void> {
+  private async handleDeath(client: KeyboardClient, cause: KeyboardError, fromTopicLoop: boolean): Promise<void> {
     if (session.client !== client) return
     // The one death the connect screen cannot report: the session was up and
     // ended on its own, so the user lands back there with no attempt of their
@@ -297,7 +297,10 @@ class KeyboardStoreClass {
     try {
       this.#connection = { phase: 'connecting', label: connected.label }
 
-      const { client } = await connectClient(connected.link)
+      // The transport already identified the protocol; no probe races here.
+      const { client } = connected.protocol === 'vial'
+        ? await connectVial(connected.link)
+        : await connectClient(connected.link)
       session.client = client
       session.onDeath = (cause) => {
         void this.handleDeath(client, cause, false)
@@ -316,6 +319,7 @@ class KeyboardStoreClass {
         info,
         version,
         layout,
+        protocol: connected.protocol,
       }
       // Prefer the name the keyboard reports over the transport label: the
       // label is a descriptor string a transport may have fallen back past
@@ -597,7 +601,7 @@ class KeyboardStoreClass {
 
   private bleProfileCmd(
     slot: number,
-    call: (c: RynkClient, slot: number) => Promise<void>,
+    call: (c: KeyboardClient, slot: number) => Promise<void>,
   ): ResultAsync<void, KeyboardError> {
     const caps = this.#device?.capabilities
     if (!caps) return notConnected<void>()
@@ -632,7 +636,7 @@ class KeyboardStoreClass {
   /// before it can reply, so the ack may never land. The session is gone either
   /// way, so the teardown runs on both outcomes and is awaited before we settle:
   /// a caller that reconnects immediately must not race a half-closed link.
-  private endSession(call: (c: RynkClient) => Promise<void>): ResultAsync<void, KeyboardError> {
+  private endSession(call: (c: KeyboardClient) => Promise<void>): ResultAsync<void, KeyboardError> {
     const label = this.#connection?.label ?? ''
     // Never rejects: a close() fault must not mask the command's own outcome.
     const close = () => ResultAsync.fromSafePromise(

--- a/src/stores/keyboard/keyboard.svelte.ts
+++ b/src/stores/keyboard/keyboard.svelte.ts
@@ -9,6 +9,8 @@ import type {
   Fork,
   KeyAction,
   LockStatus,
+  MatrixState,
+  Morse,
   PeripheralStatus,
   RynkClient,
   StorageResetMode,
@@ -180,6 +182,36 @@ async function fetchStatus(client: RynkClient, caps: DeviceCapabilities): Promis
 
 function invalid(cause: string): ResultAsync<void, KeyboardError> {
   return errAsync<void, KeyboardError>({ type: 'invalid', cause })
+}
+
+/// A backup from another keyboard must not be half-written into this one, so
+/// every table is checked against the live capabilities before the first write.
+function validateConfigShape(config: KeyboardConfig, caps: DeviceCapabilities): string | null {
+  if (config.keymap.length !== caps.num_layers)
+    return `keymap: ${config.keymap.length} layers, expected ${caps.num_layers}`
+  for (const [l, rows] of config.keymap.entries()) {
+    if (rows.length !== caps.num_rows)
+      return `keymap layer ${l}: ${rows.length} rows, expected ${caps.num_rows}`
+    for (const [r, row] of rows.entries()) {
+      if (row.length !== caps.num_cols)
+        return `keymap layer ${l} row ${r}: ${row.length} cols, expected ${caps.num_cols}`
+    }
+  }
+  if (config.combos.length !== caps.max_combos)
+    return `combos: ${config.combos.length} slots, expected ${caps.max_combos}`
+  if (config.morses.length !== caps.max_morse)
+    return `morses: ${config.morses.length} slots, expected ${caps.max_morse}`
+  if (config.forks.length !== caps.max_forks)
+    return `forks: ${config.forks.length} slots, expected ${caps.max_forks}`
+  if (config.encoders.length !== caps.num_encoders)
+    return `encoders: ${config.encoders.length}, expected ${caps.num_encoders}`
+  if (config.encoders.some(layers => layers.length !== caps.num_layers))
+    return `encoders: every encoder needs ${caps.num_layers} layers`
+  if (config.macros.length !== caps.macro_space_size)
+    return `macros: ${config.macros.length} bytes, expected ${caps.macro_space_size}`
+  if (config.defaultLayer < 0 || config.defaultLayer >= caps.num_layers)
+    return `default layer ${config.defaultLayer} out of range`
+  return null
 }
 
 class KeyboardStoreClass {
@@ -373,6 +405,69 @@ class KeyboardStoreClass {
     })
   }
 
+  setMorse(index: number, morse: Morse): ResultAsync<void, KeyboardError> {
+    if (!this.#config) return invalid('not connected')
+    if (index < 0 || index >= this.#config.morses.length) return invalid(`morse ${index} out of range`)
+
+    return runMutation({
+      push: () => {
+        const snapshot = this.#config!.morses[index]!
+        this.#config!.morses[index] = morse
+        return snapshot
+      },
+      call: c => c.set_morse(index, morse),
+      undo: (snapshot) => { if (this.#config) this.#config.morses[index] = snapshot },
+    })
+  }
+
+  setFork(index: number, fork: Fork): ResultAsync<void, KeyboardError> {
+    if (!this.#config) return invalid('not connected')
+    if (index < 0 || index >= this.#config.forks.length) return invalid(`fork ${index} out of range`)
+
+    return runMutation({
+      push: () => {
+        const snapshot = this.#config!.forks[index]!
+        this.#config!.forks[index] = fork
+        return snapshot
+      },
+      call: c => c.set_fork(index, fork),
+      undo: (snapshot) => { if (this.#config) this.#config.forks[index] = snapshot },
+    })
+  }
+
+  setEncoder(encoder: number, layer: number, action: EncoderAction): ResultAsync<void, KeyboardError> {
+    if (!this.#config) return invalid('not connected')
+    const layers = this.#config.encoders[encoder]
+    if (!layers) return invalid(`encoder ${encoder} out of range`)
+    if (layer < 0 || layer >= layers.length) return invalid(`layer ${layer} out of range`)
+
+    return runMutation({
+      push: () => {
+        const snapshot = this.#config!.encoders[encoder]![layer]!
+        this.#config!.encoders[encoder]![layer] = action
+        return snapshot
+      },
+      call: c => c.set_encoder(encoder, layer, action),
+      undo: (snapshot) => { if (this.#config) this.#config.encoders[encoder]![layer] = snapshot },
+    })
+  }
+
+  setDefaultLayer(layer: number): ResultAsync<void, KeyboardError> {
+    const caps = this.#device?.capabilities
+    if (!this.#config || !caps) return invalid('not connected')
+    if (layer < 0 || layer >= caps.num_layers) return invalid(`layer ${layer} out of range`)
+
+    return runMutation({
+      push: () => {
+        const snapshot = this.#config!.defaultLayer
+        this.#config!.defaultLayer = layer
+        return snapshot
+      },
+      call: c => c.set_default_layer(layer),
+      undo: (snapshot) => { if (this.#config) this.#config.defaultLayer = snapshot },
+    })
+  }
+
   /// Replace the whole macro region. Macros are one packed byte run with no
   /// per-slot addressing, so editing any of them rewrites all of them; the
   /// chunked writes share a chain slot to keep that atomic from the UI's side.
@@ -434,6 +529,43 @@ class KeyboardStoreClass {
           this.#status.matrixState = await c.get_matrix_state()
       }
       return status
+    })
+  }
+
+  /// Matrix state has no topic: the tester polls this while visible. Gated on
+  /// the cached lock status so a locked device is never asked (it would reject).
+  refreshMatrixState(): ResultAsync<MatrixState | null, KeyboardError> {
+    return runCommand(async (c) => {
+      if (!this.#status || this.#status.lockStatus.locked) return null
+      const state = await c.get_matrix_state()
+      this.#status.matrixState = state
+      return state
+    })
+  }
+
+  /// Restore a backup: write every table the config carries, then re-read the
+  /// device's view in the same chain slot so the store never shows the draft.
+  importConfig(config: KeyboardConfig): ResultAsync<void, KeyboardError> {
+    const caps = this.#device?.capabilities
+    if (!this.#config || !caps) return invalid('not connected')
+    const shape = validateConfigShape(config, caps)
+    if (shape) return invalid(shape)
+
+    return runCommand(async (c) => {
+      await c.set_behavior(config.behavior)
+      await c.set_default_layer(config.defaultLayer)
+      await c.write_all_keymap(config.keymap.flat().flat())
+      await c.write_all_combos(config.combos)
+      await c.write_all_morses(config.morses)
+      for (const [i, fork] of config.forks.entries()) await c.set_fork(i, fork)
+      for (const [e, layers] of config.encoders.entries()) {
+        for (const [l, action] of layers.entries()) await c.set_encoder(e, l, action)
+      }
+      const chunk = Math.max(1, caps.macro_chunk_size)
+      for (let offset = 0; offset < config.macros.length; offset += chunk) {
+        await c.set_macro(offset, { data: config.macros.slice(offset, offset + chunk) })
+      }
+      this.#config = await fetchConfig(c, caps)
     })
   }
 

--- a/src/stores/keyboard/keyboard.test.ts
+++ b/src/stores/keyboard/keyboard.test.ts
@@ -133,7 +133,15 @@ class FakeClient {
   read_all_keymap() { return this.log('read_all_keymap', [...this.keymap]) }
   read_all_combos() { return this.log('read_all_combos', []) }
   read_all_morses() { return this.log('read_all_morses', this.morses.map(m => structuredClone(m))) }
-  get_fork(i: number) { return this.log(`get_fork:${i}`, structuredClone(this.forks[i]!)) }
+  get_fork(i: number) {
+    // Mirrors the firmware: the fork table answers past-the-end with Invalid.
+    if (i >= this.forks.length) {
+      this.calls.push(`get_fork:${i}`)
+      return Promise.reject(rejection('Rejected', 'device rejected Invalid'))
+    }
+    return this.log(`get_fork:${i}`, structuredClone(this.forks[i]!))
+  }
+
   get_encoder(e: number, l: number) { return this.log(`get_encoder:${e},${l}`, structuredClone(this.encoders[e]!)) }
   get_lock_status() {
     return this.log('get_lock_status', {
@@ -442,6 +450,18 @@ async function fullConnected(): Promise<FakeClient> {
 }
 
 describe('morse / fork / encoder / default layer', () => {
+  it('connects when the fork table is shorter than its capacity', async () => {
+    // max_forks reports build-time capacity; the firmware answers reads past
+    // the live table with Invalid, which ends the scan instead of the connect.
+    const client = new FakeClient()
+    client.caps = { ...FULL_CAPS, max_forks: 4 }
+    client.morses = [emptyMorse(), emptyMorse()]
+    client.forks = [emptyFork()]
+    client.encoders = [{ clockwise: 'No', counter_clockwise: 'No' }]
+    await connected(client)
+    expect(keyboardStore.config?.forks).toHaveLength(1)
+  })
+
   it('writes a morse slot optimistically', async () => {
     await fullConnected()
     const morse: Morse = { ...emptyMorse(), actions: [[0b10, 'No']] }

--- a/src/stores/keyboard/keyboard.test.ts
+++ b/src/stores/keyboard/keyboard.test.ts
@@ -1,4 +1,5 @@
-import type { ConnectedDevice, DeviceCapabilities, KeyAction, RynkClient, StorageResetMode, TopicEvent } from '../../rynk'
+import type { ConnectedDevice, DeviceCapabilities, EncoderAction, Fork, KeyAction, Morse, RynkClient, StorageResetMode, TopicEvent } from '../../rynk'
+import type { KeyboardConfig } from './types'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const connectClient = vi.hoisted(() => vi.fn())
@@ -32,6 +33,50 @@ const CAPS: DeviceCapabilities = {
 
 const BLE_CAPS: DeviceCapabilities = { ...CAPS, ble_enabled: true, num_ble_profiles: 3 }
 
+/// Every optional table present, for the morse/fork/encoder mutations.
+const FULL_CAPS: DeviceCapabilities = { ...CAPS, max_morse: 2, max_forks: 1, num_encoders: 1 }
+
+function emptyMorse(): Morse {
+  return {
+    profile: {
+      unilateral_tap: undefined,
+      enable_flow_tap: undefined,
+      mode: undefined,
+      hold_timeout_ms: undefined,
+      gap_timeout_ms: undefined,
+      quick_tap_timeout_ms: undefined,
+    },
+    actions: [],
+  }
+}
+
+function emptyFork(): Fork {
+  const mods = () => ({
+    left_ctrl: false,
+    left_shift: false,
+    left_alt: false,
+    left_gui: false,
+    right_ctrl: false,
+    right_shift: false,
+    right_alt: false,
+    right_gui: false,
+  })
+  const state = () => ({
+    modifiers: mods(),
+    leds: { num_lock: false, caps_lock: false, scroll_lock: false, compose: false, kana: false },
+    mouse: { button1: false, button2: false, button3: false, button4: false, button5: false, button6: false, button7: false, button8: false },
+  })
+  return {
+    trigger: 'No',
+    negative_output: 'No',
+    positive_output: 'No',
+    match_any: state(),
+    match_none: state(),
+    kept_modifiers: mods(),
+    bindable: false,
+  }
+}
+
 function rejection(name: string, message: string): Error {
   const e = new Error(message)
   e.name = name
@@ -52,6 +97,12 @@ class FakeClient {
   calls: string[] = []
   /// Queued failure for the next set_key, so tests can force a rollback.
   failSetKey: Error | null = null
+  /// Same, for set_morse.
+  failSetMorse: Error | null = null
+  morses: Morse[] = []
+  forks: Fork[] = []
+  encoders: EncoderAction[] = []
+  defaultLayer = 0
   matrixReads = 0
   bleProfile = 0
   /// Queued failure for the next session-ending command (reboot et al).
@@ -78,10 +129,12 @@ class FakeClient {
   get_capabilities() { return this.log('get_capabilities', this.caps) }
   get_layout() { return this.log('get_layout', { default_variant: 0, variants: [] }) }
   get_behavior() { return this.log('get_behavior', {}) }
-  get_default_layer() { return this.log('get_default_layer', 0) }
+  get_default_layer() { return this.log('get_default_layer', this.defaultLayer) }
   read_all_keymap() { return this.log('read_all_keymap', [...this.keymap]) }
   read_all_combos() { return this.log('read_all_combos', []) }
-  read_all_morses() { return this.log('read_all_morses', []) }
+  read_all_morses() { return this.log('read_all_morses', this.morses.map(m => structuredClone(m))) }
+  get_fork(i: number) { return this.log(`get_fork:${i}`, structuredClone(this.forks[i]!)) }
+  get_encoder(e: number, l: number) { return this.log(`get_encoder:${e},${l}`, structuredClone(this.encoders[e]!)) }
   get_lock_status() {
     return this.log('get_lock_status', {
       locked: this.locked,
@@ -130,6 +183,43 @@ class FakeClient {
     this.failSetKey = null
     if (fail) throw fail
     this.keymap[row * CAPS.num_cols + col] = action
+  }
+
+  async set_morse(i: number, config: Morse) {
+    this.calls.push(`set_morse:${i}`)
+    const fail = this.failSetMorse
+    this.failSetMorse = null
+    if (fail) throw fail
+    this.morses[i] = config
+  }
+
+  async set_fork(i: number, config: Fork) {
+    this.calls.push(`set_fork:${i}`)
+    this.forks[i] = config
+  }
+
+  async set_encoder(e: number, _l: number, action: EncoderAction) {
+    this.calls.push(`set_encoder:${e}`)
+    this.encoders[e] = action
+  }
+
+  async set_default_layer(l: number) {
+    this.calls.push(`set_default_layer:${l}`)
+    this.defaultLayer = l
+  }
+
+  async set_behavior() { this.calls.push('set_behavior') }
+
+  async write_all_keymap(actions: KeyAction[]) {
+    this.calls.push('write_all_keymap')
+    this.keymap = actions
+  }
+
+  async write_all_combos() { this.calls.push('write_all_combos') }
+
+  async write_all_morses(configs: Morse[]) {
+    this.calls.push('write_all_morses')
+    this.morses = configs
   }
 
   async lock() {
@@ -322,6 +412,109 @@ describe('lock gate', () => {
     const result = await keyboardStore.unlockPoll()
     expect(result._unsafeUnwrap().locked).toBe(false)
     expect(keyboardStore.status?.matrixState).toEqual({ pressed_bitmap: [0] })
+  })
+
+  it('skips the gated matrix poll while locked', async () => {
+    const client = new FakeClient()
+    client.locked = true
+    await connected(client)
+    const result = await keyboardStore.refreshMatrixState()
+    expect(result._unsafeUnwrap()).toBeNull()
+    expect(client.matrixReads).toBe(0)
+  })
+
+  it('caches the polled matrix state when unlocked', async () => {
+    const client = await connected()
+    const before = client.matrixReads
+    const result = await keyboardStore.refreshMatrixState()
+    expect(result._unsafeUnwrap()).toEqual({ pressed_bitmap: [0] })
+    expect(client.matrixReads).toBe(before + 1)
+  })
+})
+
+async function fullConnected(): Promise<FakeClient> {
+  const client = new FakeClient()
+  client.caps = FULL_CAPS
+  client.morses = [emptyMorse(), emptyMorse()]
+  client.forks = [emptyFork()]
+  client.encoders = [{ clockwise: 'No', counter_clockwise: 'No' }]
+  return await connected(client)
+}
+
+describe('morse / fork / encoder / default layer', () => {
+  it('writes a morse slot optimistically', async () => {
+    await fullConnected()
+    const morse: Morse = { ...emptyMorse(), actions: [[0b10, 'No']] }
+    const result = await keyboardStore.setMorse(1, morse)
+    expect(result.isOk()).toBe(true)
+    expect(keyboardStore.config?.morses[1]).toEqual(morse)
+  })
+
+  it('rolls a rejected morse write back', async () => {
+    const client = await fullConnected()
+    client.failSetMorse = rejection('Rejected', 'device rejected Invalid')
+    const morse: Morse = { ...emptyMorse(), actions: [[0b10, 'No']] }
+    const result = await keyboardStore.setMorse(0, morse)
+    expect(result._unsafeUnwrapErr()).toEqual({ type: 'rynk', code: 'Invalid' })
+    expect(keyboardStore.config?.morses[0]).toEqual(emptyMorse())
+  })
+
+  it('rejects an out-of-range morse slot without touching the device', async () => {
+    const client = await fullConnected()
+    const before = client.calls.length
+    expect((await keyboardStore.setMorse(2, emptyMorse()))._unsafeUnwrapErr().type).toBe('invalid')
+    expect(client.calls).toHaveLength(before)
+  })
+
+  it('writes a fork slot', async () => {
+    await fullConnected()
+    const fork: Fork = { ...emptyFork(), trigger: 'Transparent' }
+    const result = await keyboardStore.setFork(0, fork)
+    expect(result.isOk()).toBe(true)
+    expect(keyboardStore.config?.forks[0]).toEqual(fork)
+  })
+
+  it('writes an encoder action for one layer', async () => {
+    const client = await fullConnected()
+    const action: EncoderAction = { clockwise: 'Transparent', counter_clockwise: 'No' }
+    const result = await keyboardStore.setEncoder(0, 0, action)
+    expect(result.isOk()).toBe(true)
+    expect(keyboardStore.config?.encoders[0]![0]).toEqual(action)
+    expect(client.calls).toContain('set_encoder:0')
+  })
+
+  it('sets the default layer and rejects one out of range', async () => {
+    const client = await fullConnected()
+    expect((await keyboardStore.setDefaultLayer(0)).isOk()).toBe(true)
+    expect(client.calls).toContain('set_default_layer:0')
+    expect((await keyboardStore.setDefaultLayer(9))._unsafeUnwrapErr().type).toBe('invalid')
+  })
+})
+
+describe('import', () => {
+  it('refuses a config from a different geometry before writing', async () => {
+    const client = await fullConnected()
+    const before = client.calls.length
+    const config = { ...keyboardStore.config!, keymap: [[['No']]] } as KeyboardConfig
+    const result = await keyboardStore.importConfig(config)
+    expect(result._unsafeUnwrapErr().type).toBe('invalid')
+    expect(client.calls).toHaveLength(before)
+  })
+
+  it('writes every table then refetches the device view', async () => {
+    const client = await fullConnected()
+    // Reads through the store's $state proxy; structuredClone can't.
+    const config = JSON.parse(JSON.stringify(keyboardStore.config)) as KeyboardConfig
+    config.keymap[0]![0]![1] = 'Transparent'
+    client.calls.length = 0
+
+    const result = await keyboardStore.importConfig(config)
+    expect(result.isOk()).toBe(true)
+    for (const call of ['set_behavior', 'set_default_layer:0', 'write_all_keymap', 'write_all_combos', 'write_all_morses', 'set_fork:0', 'set_encoder:0']) {
+      expect(client.calls).toContain(call)
+    }
+    // The store shows the device's own view, re-read after the writes.
+    expect(keyboardStore.config?.keymap[0]![0]![1]).toBe('Transparent')
   })
 })
 

--- a/src/stores/keyboard/keyboard.test.ts
+++ b/src/stores/keyboard/keyboard.test.ts
@@ -3,7 +3,8 @@ import type { KeyboardConfig } from './types'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const connectClient = vi.hoisted(() => vi.fn())
-vi.mock('../../rynk', () => ({ connectClient }))
+const connectVial = vi.hoisted(() => vi.fn())
+vi.mock('../../rynk', () => ({ connectClient, connectVial }))
 
 const { keyboardStore } = await import('./keyboard.svelte')
 
@@ -281,19 +282,21 @@ class FakeClient {
   free() { this.freed = true }
 }
 
-function connect(client: FakeClient): ConnectedDevice {
+function connect(client: FakeClient, protocol: 'rynk' | 'vial' = 'rynk'): ConnectedDevice {
   const link = {
     label: 'fake',
     send: async () => {},
     recv: async () => new Uint8Array(0),
     close: async () => { client.die() },
   }
+  // Arm both routes; the protocol tag decides which one the store takes.
   connectClient.mockResolvedValue({ client: client as unknown as RynkClient, major: 1, minor: 0 })
-  return { link, label: 'fake' } as unknown as ConnectedDevice
+  connectVial.mockResolvedValue({ client: client as unknown as RynkClient })
+  return { link, label: 'fake', protocol } as unknown as ConnectedDevice
 }
 
-async function connected(client = new FakeClient()): Promise<FakeClient> {
-  const result = await keyboardStore.initStore(connect(client))
+async function connected(client = new FakeClient(), protocol: 'rynk' | 'vial' = 'rynk'): Promise<FakeClient> {
+  const result = await keyboardStore.initStore(connect(client, protocol))
   expect(result.isOk()).toBe(true)
   return client
 }
@@ -301,6 +304,7 @@ async function connected(client = new FakeClient()): Promise<FakeClient> {
 beforeEach(async () => {
   await keyboardStore.resetStore()
   connectClient.mockReset()
+  connectVial.mockReset()
 })
 
 describe('connect', () => {
@@ -700,5 +704,40 @@ describe('disconnect', () => {
     await connected()
     await keyboardStore.resetStore()
     expect(keyboardStore.connection).toBeNull()
+  })
+})
+
+describe('vial protocol', () => {
+  /// The wasm VialClient rejects what the wire cannot express; this fake only
+  /// mirrors those rejections — everything else is protocol-blind.
+  class FakeVialClient extends FakeClient {
+    override async set_default_layer(l: number) {
+      this.calls.push(`set_default_layer:${l}`)
+      if (l !== 0) throw rejection('Rejected', 'device rejected Unimplemented')
+    }
+  }
+
+  it('routes the connect through connectVial and tags the device', async () => {
+    await connected(new FakeVialClient(), 'vial')
+    expect(connectVial).toHaveBeenCalledOnce()
+    expect(connectClient).not.toHaveBeenCalled()
+    expect(keyboardStore.device?.protocol).toBe('vial')
+    expect(keyboardStore.config?.keymap).toEqual([[['No', 'No']]])
+  })
+
+  it('rolls back the default layer when the client rejects it', async () => {
+    await connected(new FakeVialClient(), 'vial')
+    const result = await keyboardStore.setDefaultLayer(0)
+    expect(result.isOk()).toBe(true)
+    // num_layers is 1, so exercise the rejection through the client directly:
+    // a multi-layer board would pass validation and hit the same rejection.
+    const client = new FakeVialClient()
+    client.caps = { ...CAPS, num_layers: 2, num_rows: 1, num_cols: 2 }
+    client.keymap = ['No', 'No', 'No', 'No']
+    await keyboardStore.resetStore()
+    await connected(client, 'vial')
+    const rejected = await keyboardStore.setDefaultLayer(1)
+    expect(rejected.isErr()).toBe(true)
+    expect(keyboardStore.config?.defaultLayer).toBe(0)
   })
 })

--- a/src/stores/keyboard/types.ts
+++ b/src/stores/keyboard/types.ts
@@ -16,6 +16,7 @@ import type {
   MatrixState,
   Morse,
   PeripheralStatus,
+  Protocol,
   ProtocolVersion,
 } from '../../rynk'
 import type { KeyboardError } from './errors'
@@ -34,6 +35,9 @@ export interface KeyboardDevice {
   info: DeviceInfo
   version: ProtocolVersion
   layout: LayoutInfo
+  /// Which wire protocol the session speaks; drives the few UI affordances
+  /// Vial cannot express (default layer, reboot, live status).
+  protocol: Protocol
 }
 
 export interface KeyboardConfig {


### PR DESCRIPTION
## Summary

Adds Vial-protocol support, so the app can configure every released RMK keyboard (whose firmware still defaults to `vial`), keyboards behind the dongle's new Vial relay, and plain vial-qmk boards — alongside the existing rynk path. The branch carries the `vial` line's earlier store/editor/qemu groundwork; the capstone commit is `feat: speak the Vial protocol beside rynk`.

- **Protocol engine lives upstream**, mirrored byte-for-byte from the firmware's own Vial service: [`rmk-rs/rmk@feat/vial-host-client`](https://github.com/rmk-rs/rmk/tree/feat/vial-host-client) (`rynk::vial` engine, `rynk-wasm --features vial` → `connect_vial()` + `VialClient`, and the via keycode conversion moved into `rmk-types` so host and firmware share one mapping). All three pins move to `0fd8785d6`; re-bump once that branch lands on rmk main.
- **Transports**: WebHID accepts the classic `0xFF60` page beside rynk's `0xFF14`; native gains a hidapi transport (USB and OS-bonded Bluetooth) with a lockstep pump and a 3 s reply watchdog.
- **Routing**: the interface a device was found on decides the protocol — no probing. The store drives both wasm clients through one structural `KeyboardClient` type and is otherwise untouched.
- **Capability-honest UI**: keymap, encoders, macros (same wire format), combos, tap dance ↔ Morse, behavior timeouts, unlock ceremony, matrix tester, bootloader jump and EEPROM reset all work over Vial; forks, default layer, reboot, BLE profiles, and live status are protocol-inexpressible and stay hidden behind the synthesized capabilities plus a `device.protocol` tag (Vial badge on the Device page).

Known limits vs vial-gui: no key-override editing, no full QMK-settings tree, no VialRGB, and macros with 16-bit extended ops stay unsupported (as on the rynk path). Boards built with a non-default `combo_max_length > 4` mis-parse combos over Vial — same as vial-gui; use rynk there.

## Test plan

- [x] rmk side: all three firmware feature rows (489/549/472 tests), rmk-types (26), `rynk::vial` engine (12), `host.sh` extended with vial rows (tests, clippy `-D warnings`, wasm build + generated `.d.ts` typecheck)
- [x] GUI: 136 vitest unit tests (incl. vial routing/rollback cases), qemu end-to-end 31 tests (rynk regression), `svelte-check` 0/0, eslint clean, `cargo clippy` clean
- [x] `src-tauri` resolves and builds against the bumped pin
- [ ] Real-hardware pass (RMK-vial board + a vial-qmk board, cross-checked against vial-gui) — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)